### PR TITLE
Add at inbounds and propagate_inbounds

### DIFF
--- a/src/set_get.jl
+++ b/src/set_get.jl
@@ -50,16 +50,17 @@ Access ```.data``` field of a ```ComponentArray```, which contains the array tha
     ComponentIndex(getproperty(IdxMap, s))
 
 # Get ComponentArray index
-@inline Base.getindex(x::ComponentArray, idx::FlatIdx...) = Base.maybeview(getdata(x), idx...)
-@inline Base.getindex(x::ComponentArray, ::Colon) = @view getdata(x)[:]
+
+Base.@propagate_inbounds Base.getindex(x::ComponentArray, idx::FlatIdx...) = Base.maybeview(getdata(x), idx...)
+Base.@propagate_inbounds Base.getindex(x::ComponentArray, ::Colon) = @view getdata(x)[:]
 @inline Base.getindex(x::ComponentArray, ::Colon...) = x
-@inline Base.getindex(x::ComponentArray, idx...) = getindex(x, toval.(idx)...)
+Base.@propagate_inbounds Base.getindex(x::ComponentArray, idx...) = getindex(x, toval.(idx)...)
 @inline Base.getindex(x::ComponentArray, idx::Val...) = _getindex(x, idx...)
 
 # Set ComponentArray index
-@inline Base.setindex!(x::ComponentArray, v, idx::FlatIdx...) = setindex!(getdata(x), v, idx...)
-@inline Base.setindex!(x::ComponentArray, v, ::Colon) = setindex!(getdata(x), v, :)
-@inline Base.setindex!(x::ComponentArray, v, idx...) = setindex!(x, v, toval.(idx)...)
+Base.@propagate_inbounds Base.setindex!(x::ComponentArray, v, idx::FlatIdx...) = setindex!(getdata(x), v, idx...)
+Base.@propagate_inbounds Base.setindex!(x::ComponentArray, v, ::Colon) = setindex!(getdata(x), v, :)
+Base.@propagate_inbounds Base.setindex!(x::ComponentArray, v, idx...) = setindex!(x, v, toval.(idx)...)
 @inline Base.setindex!(x::ComponentArray, v, idx::Val...) = _setindex!(x, v, idx...)
 
 
@@ -74,11 +75,13 @@ Access ```.data``` field of a ```ComponentArray```, which contains the array tha
     inds = map(i -> i.idx, ci)
     axs = map(i -> i.ax, ci)
     axs = remove_nulls(axs...)
-    return :(Base.@_inline_meta; ComponentArray(Base.maybeview(getdata(x), $inds...), $axs...))
+    # the index must be valid after computing `ci`
+    :(Base.@_inline_meta; @inbounds ComponentArray(Base.maybeview(getdata(x), $inds...), $axs...))
 end
 
 @generated function _setindex!(x::ComponentArray, v, idx...)
     ci = getindex.(getaxes(x), getval.(idx))
     inds = map(i -> i.idx, ci)
-    return :(Base.@_inline_meta; setindex!(getdata(x), v, $inds...))
+    # the index must be valid after computing `ci`
+    return :(Base.@_inline_meta; @inbounds setindex!(getdata(x), v, $inds...))
 end


### PR DESCRIPTION
This PR adds `@inbounds` and `@propagate_inbounds` in appropriated places to optimize the performance.

PR:
```julia
julia> using ComponentArrays

julia> c = (a=2, b=[1, 2]);

julia> x = ComponentArray(a=1, b=[2, 1, 4], c=c)
ComponentVector{Float64}(a = 1.0, b = [2.0, 1.0, 4.0], c = (a = 2.0, b = [1.0, 2.0]))

julia> foo(x) = x.a
foo (generic function with 1 method)

julia> @code_native debuginfo=:none foo(x)
        .text
        movq    (%rdi), %rax
        movq    (%rax), %rax
        vmovsd  (%rax), %xmm0           # xmm0 = mem[0],zero
        retq
        nopl    (%rax,%rax)
```

Master:
```julia
julia> @code_native debuginfo=:none foo(x)
        .text
        movq    (%rdi), %rdi
        cmpq    $0, 8(%rdi)
        je      L18
        movq    (%rdi), %rax
        vmovsd  (%rax), %xmm0           # xmm0 = mem[0],zero
        retq
L18:
        pushq   %rbp
        movq    %rsp, %rbp
        movq    %rsp, %rax
        leaq    -16(%rax), %rsi
        movq    %rsi, %rsp
        movq    $1, -16(%rax)
        movabsq $jl_bounds_error_ints, %rax
        movl    $1, %edx
        callq   *%rax
        nopl    (%rax)
```