### PR TITLE
Less verbose type printing in stacktrace

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ComponentArrays"
 uuid = "b0b7db55-cfe3-40fc-9ded-d10e2dbeff66"
 authors = ["Jonnie Diegelman <47193959+jonniedie@users.noreply.github.com>"]
-version = "0.6.12"
+version = "0.6.13"
 
 [deps]
 ArrayInterface = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"

--- a/src/show.jl
+++ b/src/show.jl
@@ -25,7 +25,10 @@ Base.show(io::IO, ci::ComponentIndex) = print(io, "ComponentIndex($(ci.idx), $(c
 
 
 # Show ComponentArrays
-Base.show(io::IO, ::Type{<:ComponentArray}) = print(io, "ComponentArray") # do not pollute the stacktrace with verbose type printing
+Base.show(io::IO, ::MIME"text/plain", ::Type{ComponentArray{T,N,A,Ax}}) where {T,N,A,Ax} = print(io, "ComponentArray{$T,$N,$A,$Ax}") # make `typeof(u)` show the full type
+Base.show(io::IO, ::Type{<:ComponentArray{T, N}}) where {T, N} = print(io, "ComponentArray{$T, $N}") # do not pollute the stacktrace with verbose type printing
+Base.show(io::IO, ::Type{<:ComponentArray{T, 1}}) where T = print(io, "ComponentVector{$T}")
+Base.show(io::IO, ::Type{<:ComponentArray{T, 2}}) where T = print(io, "ComponentMatrix{$T}")
 function Base.show(io::IO, x::ComponentVector)
     print(io, "(")
     for (i,key) in enumerate(keys(x))

--- a/src/show.jl
+++ b/src/show.jl
@@ -25,6 +25,7 @@ Base.show(io::IO, ci::ComponentIndex) = print(io, "ComponentIndex($(ci.idx), $(c
 
 
 # Show ComponentArrays
+Base.show(io::IO, ::Type{<:ComponentArray}) = print(io, "ComponentArray") # do not pollute the stacktrace with verbose type printing
 function Base.show(io::IO, x::ComponentVector)
     print(io, "(")
     for (i,key) in enumerate(keys(x))


### PR DESCRIPTION
```
julia> foo(u0) = sqrt(-u0[1])
foo (generic function with 1 method)

julia> foo(u0)
ERROR: DomainError with -2.8e6:
sqrt will only return a complex result if called with a complex argument. Try sqrt(Complex(x)).
Stacktrace:
 [1] throw_complex_domainerror(::Symbol, ::Float64) at ./math.jl:33
 [2] sqrt at ./math.jl:573 [inlined]
 [3] foo(::ComponentArray{Float64,1,Array{Float64,1},Tuple{Axis{(outdoor_hex = ViewAxis(1:20, Axis((Ps = 1:4, hs = 5:8, Ms = 9:12, Us = 13:16, TWalls = 17:20))), indoor_hex = ViewAxis(21:40, Axis((Ps = 1:4, hs = 5:8, Ms = 9:12, Us = 13:16, TWalls = 17:20))))}}}) at ./REPL[481]:1
 [4] top-level scope at REPL[482]:1

julia> Base.show(io::IO, ::Type{<:ComponentArray}) = print(io, "ComponentArray")

julia> foo(u0)
ERROR: DomainError with -2.8e6:
sqrt will only return a complex result if called with a complex argument. Try sqrt(Complex(x)).
Stacktrace:
 [1] throw_complex_domainerror(::Symbol, ::Float64) at ./math.jl:33
 [2] sqrt at ./math.jl:573 [inlined]
 [3] foo(::ComponentArray) at ./REPL[481]:1
 [4] top-level scope at REPL[484]:1
```