### PR TITLE
Allow ArrayInterface 3, support ArrayInterface

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -9,7 +9,7 @@ LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 
 [compat]
-ArrayInterface = "2.8.0"
+ArrayInterface = "2.8, 3"
 Requires = "1.0.1"
 julia = "1"
 

--- a/Project.toml
+++ b/Project.toml
@@ -9,7 +9,7 @@ LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 
 [compat]
-ArrayInterface = "2.8, 3"
+ArrayInterface = "2.13, 3"
 Requires = "1.0.1"
 julia = "1"
 

--- a/src/componentarray.jl
+++ b/src/componentarray.jl
@@ -319,5 +319,12 @@ end
 
 Base.IndexStyle(::Type{<:ComponentArray{T,N,<:A,<:Axes}}) where {T,N,A,Axes} = IndexStyle(A)
 
-ArrayInterface.device(::Type{<:ComponentArray}) = ArrayInterface.CPUIndex()
+
+ArrayInterface.parent_type(::Type{ComponentArray{T,N,A,Axes}}) where {T,N,A,Axes} = A
+ArrayInterface.size(A::ComponentArray) = ArrayInterface.size(parent(A))
+ArrayInterface.strides(A::ComponentArray) = ArrayInterface.strides(parent(A))
+for f in [:device, :stride_rank, :contiguous_axis, :contiguous_batch_size, :dense_dims] 
+    @eval ArrayInterface.$f(::ComponentArray{T,N,A,Axes}) where {T,N,A,Axes} = ArrayInterface.$f(A)
+end
+
 

--- a/src/componentarray.jl
+++ b/src/componentarray.jl
@@ -318,3 +318,6 @@ function Base.permutedims(x::ComponentArray, dims)
 end
 
 Base.IndexStyle(::Type{<:ComponentArray{T,N,<:A,<:Axes}}) where {T,N,A,Axes} = IndexStyle(A)
+
+ArrayInterface.device(::Type{<:ComponentArray}) = ArrayInterface.CPUIndex()
+

--- a/src/componentarray.jl
+++ b/src/componentarray.jl
@@ -324,7 +324,7 @@ ArrayInterface.parent_type(::Type{ComponentArray{T,N,A,Axes}}) where {T,N,A,Axes
 ArrayInterface.size(A::ComponentArray) = ArrayInterface.size(parent(A))
 ArrayInterface.strides(A::ComponentArray) = ArrayInterface.strides(parent(A))
 for f in [:device, :stride_rank, :contiguous_axis, :contiguous_batch_size, :dense_dims] 
-    @eval ArrayInterface.$f(::ComponentArray{T,N,A,Axes}) where {T,N,A,Axes} = ArrayInterface.$f(A)
+    @eval ArrayInterface.$f(::Type{ComponentArray{T,N,A,Axes}}) where {T,N,A,Axes} = ArrayInterface.$f(A)
 end
 
 


### PR DESCRIPTION
`RecursiveFactorization.lu` should work:
```julia
julia> using RecursiveFactorization, ComponentArrays, BenchmarkTools

julia> A = rand(20,20);

julia> CA = ComponentArray(A, (Axis(a = 1, b = 2:5, c= 6:20), Axis(d = 1:11, e = 12:20)))
20×20 ComponentMatrix{Float64} with axes Axis(a = 1, b = 2:5, c = 6:20) × Axis(d = 1:11, e = 12:20)
 0.792297   0.920946    0.787967   0.44453    0.372399  0.829221   0.926357   0.940149   0.217544    …  0.884185   0.500896   0.437198     0.523697   0.775704    0.866969    0.647117   0.197122
 0.51889    0.0850669   0.309129   0.800278   0.520421  0.0837537  0.0819355  0.610569   0.619184       0.0469312  0.0461996  0.000108896  0.447549   0.780642    0.100468    0.824336   0.930264
 0.86085    0.116267    0.141935   0.830085   0.826916  0.755773   0.511896   0.263067   0.285642       0.119513   0.440049   0.745345     0.242581   0.830945    0.291005    0.679063   0.217987
 0.199206   0.687761    0.981128   0.0195515  0.877416  0.395926   0.0861121  0.488198   0.248053       0.971731   0.105545   0.314973     0.428733   0.431964    0.735564    0.120235   0.175562
 0.803755   0.526944    0.941458   0.390808   0.509174  0.554689   0.671636   0.644617   0.43828        0.42656    0.887439   0.45515      0.657442   0.69448     0.00242175  0.531906   0.414432
 0.988017   0.200386    0.877335   0.674942   0.616311  0.0642937  0.637999   0.394308   0.118526    …  0.856059   0.505046   0.846206     0.582761   0.323335    0.0241551   0.0701344  0.367021
 0.999558   0.190124    0.332883   0.576808   0.86233   0.0353636  0.963261   0.835241   0.237633       0.22654    0.834873   0.987072     0.704351   0.459602    0.193632    0.327695   0.248773
 0.444506   0.794923    0.969768   0.131421   0.695839  0.592099   0.0183144  0.258682   0.922366       0.962108   0.448434   0.148325     0.283102   0.602781    0.711785    0.775597   0.112608
 0.111129   0.782944    0.152266   0.190192   0.634521  0.616569   0.310043   0.753958   0.00516924     0.568963   0.98902    0.642012     0.222836   0.399607    0.193411    0.416332   0.549769
 0.846378   0.409507    0.658963   0.895919   0.763136  0.408985   0.984185   0.974032   0.681561       0.0895967  0.317083   0.132909     0.587647   0.290701    0.880873    0.714118   0.38869
 0.719386   0.395962    0.774278   0.38587    0.804354  0.541999   0.325625   0.990979   0.697488    …  0.638735   0.188201   0.644498     0.0372193  0.451285    0.0226417   0.965596   0.435106
 0.211009   0.9896      0.108219   0.146176   0.126344  0.210319   0.466166   0.933393   0.0610616      0.242922   0.465915   0.935151     0.726498   0.212136    0.259957    0.424255   0.139462
 0.0980712  0.497293    0.491229   0.655134   0.23946   0.928507   0.597618   0.611717   0.197108       0.814391   0.138363   0.757494     0.822816   0.89782     0.67449     0.315776   0.579171
 0.844787   0.932653    0.416634   0.623571   0.858204  0.0304944  0.390753   0.782568   0.474696       0.289535   0.682387   0.501013     0.568961   0.753318    0.219315    0.160231   0.686219
 0.954878   0.0924132   0.160915   0.66679    0.377309  0.129861   0.595773   0.178213   0.0633043      0.730574   0.910448   0.167637     0.668421   0.826676    0.519784    0.615609   0.625886
 0.205551   0.76434     0.0512469  0.543711   0.543169  0.155296   0.0292109  0.340881   0.0910301   …  0.267029   0.179909   0.244644     0.241828   0.570413    0.179196    0.910021   0.656621
 0.505832   0.822442    0.50703    0.619567   0.723969  0.575101   0.249339   0.0206148  0.250113       0.346489   0.881497   0.295233     0.297417   0.690904    0.465378    0.38916    0.628689
 0.881979   0.518632    0.328105   0.649174   0.902167  0.970687   0.716556   0.266545   0.285534       0.612138   0.820748   0.14744      0.87743    0.951241    0.550375    0.135934   0.358462
 0.245023   0.00955664  0.0443849  0.709473   0.78408   0.77327    0.421336   0.761772   0.283593       0.659631   0.532499   0.939848     0.944045   0.729342    0.802993    0.385053   0.229815
 0.602472   0.393082    0.604634   0.37308    0.145483  0.309185   0.464967   0.757712   0.164093       0.749907   0.742632   0.145961     0.639303   0.00180398  0.713444    0.228169   0.00252049

julia> @btime lu($CA)
  8.362 μs (2 allocations: 3.48 KiB)
LU{Float64, ComponentMatrix{Float64}}
L factor:
20×20 Matrix{Float64}:
 1.0         0.0         0.0         0.0           0.0        0.0        0.0         0.0         0.0        …  0.0         0.0        0.0        0.0        0.0        0.0        0.0       0.0       0.0
 0.211102    1.0         0.0         0.0           0.0        0.0        0.0         0.0         0.0           0.0         0.0        0.0        0.0        0.0        0.0        0.0       0.0       0.0
 0.199294    0.68446     1.0         0.0           0.0        0.0        0.0         0.0         0.0           0.0         0.0        0.0        0.0        0.0        0.0        0.0       0.0       0.0
 0.0981146   0.504114    0.494411    1.0           0.0        0.0        0.0         0.0         0.0           0.0         0.0        0.0        0.0        0.0        0.0        0.0       0.0       0.0
 0.245132   -0.0390206  -0.0402047   0.879783      1.0        0.0        0.0         0.0         0.0           0.0         0.0        0.0        0.0        0.0        0.0        0.0       0.0       0.0
 0.882369    0.369548    0.0229027   0.208464      0.240296   1.0        0.0         0.0         0.0        …  0.0         0.0        0.0        0.0        0.0        0.0        0.0       0.0       0.0
 0.519119   -0.0143554   0.15399     0.807994      0.139888  -0.830161   1.0         0.0         0.0           0.0         0.0        0.0        0.0        0.0        0.0        0.0       0.0       0.0
 0.719704    0.272921    0.589937    0.0470892    -0.302887   0.492686   0.252247    1.0         0.0           0.0         0.0        0.0        0.0        0.0        0.0        0.0       0.0       0.0
 0.444703    0.748184    0.892587   -0.0674539    -0.422343   0.4746     0.313037    0.316719    1.0           0.0         0.0        0.0        0.0        0.0        0.0        0.0       0.0       0.0
 0.205642    0.763844   -0.0519715   0.624348      0.737099  -0.823249   0.751266   -0.968142   -0.150667      0.0         0.0        0.0        0.0        0.0        0.0        0.0       0.0       0.0
 0.861231   -0.0500001  -0.160726    0.493283      0.382889   0.544949   0.367403    0.0514734  -0.332622   …  0.0         0.0        0.0        0.0        0.0        0.0        0.0       0.0       0.0
 0.988454    0.0131208   0.616325    0.270501     -0.843687  -0.260494   0.59309     0.139343   -0.829131      1.0         0.0        0.0        0.0        0.0        0.0        0.0       0.0       0.0
 0.846752    0.261747    0.413092    0.697295     -0.171497  -0.350981   0.287617   -0.0480768   0.601006      0.0310679   1.0        0.0        0.0        0.0        0.0        0.0       0.0       0.0
 0.804111    0.393973    0.741251    0.000741975  -0.935047   0.61989    0.0814095   0.750294   -0.0963975     0.371313    0.453647   1.0        0.0        0.0        0.0        0.0       0.0       0.0
 0.602739    0.29331     0.442008    0.105678     -0.87439    0.28299    0.287128    0.857947   -0.732191      0.530426   -0.509723   0.605711   1.0        0.0        0.0        0.0       0.0       0.0
 0.506056    0.764883    0.348271    0.542409      0.22464   -0.151427   0.617552   -0.768915    0.0140466  …  0.501406    0.576905   0.549992  -0.257272   1.0        0.0        0.0       0.0       0.0
 0.9553     -0.0939602  -0.172728    0.15381      -0.386436   0.171673   0.500983    0.0535261  -0.619998      0.584394   -0.877756  -0.246671   0.664617   0.37898    1.0        0.0       0.0       0.0
 0.845161    0.813056    0.117507    0.201667      0.163245  -0.538107   0.833325   -0.451238    0.079386      0.316022    0.21245   -0.109802   0.0780122  0.256051   0.799157   1.0       0.0       0.0
 0.792648    0.811241    0.555038    0.0463599    -0.878346   0.91041   -0.096382    0.790969   -0.408181      0.0683267  -0.331457   0.103808   0.52856    0.0347386  0.549886  -0.987399  1.0       0.0
 0.111179    0.802354    0.0954193   0.182611      0.715776   0.265278  -0.193452   -0.141881   -0.127051      0.123545    0.298874   0.841487   0.0153677  0.69162    0.182688  -0.116982  0.363034  1.0
U factor:
20×20 Matrix{Float64}:
 0.999558  0.190124  0.332883    0.576808    0.86233    0.0353636   0.963261   0.835241  0.237633   …   0.22654     0.834873    0.987072   0.704351    0.459602      0.193632     0.327695    0.248773
 0.0       0.949465  0.0379463   0.0244109  -0.0556951  0.202853    0.262819   0.757072  0.0108968      0.195099    0.289672    0.726778   0.577808    0.115113      0.219081     0.355078    0.0869451
 0.0       0.0       0.888814   -0.112111    0.74368    0.250033   -0.285749  -0.196446  0.193236       0.793046   -0.259109   -0.379195  -0.107127    0.261578      0.547022    -0.188109    0.0664724
 0.0       0.0       0.0         0.641664   -0.184754   0.699157    0.511894   0.245242  0.0727618      0.301722    0.0385283   0.481747   0.515392    0.665369      0.274596     0.197628    0.478068
 0.0       0.0       0.0         0.0         0.762965   0.167463   -0.266378   0.362912  0.169522       0.378146    0.294834    0.287167   0.336192    0.0463076     0.544484     0.137148   -0.245698
 0.0       0.0       0.0         0.0         0.0        0.672803   -0.266677  -0.884052  0.0114975  …   0.168219   -0.0959106  -1.15285   -0.143369    0.34734       0.0979505   -0.354278    0.0646805
 0.0       0.0       0.0         0.0         0.0        0.0        -0.968065  -0.76473   0.393264      -0.347029   -0.495136   -1.82994   -0.475784    0.247682     -0.297865     0.215312    0.493923
 0.0       0.0       0.0         0.0         0.0        0.0         0.0        1.02596   0.352547       0.0595848  -0.0792222   1.05333   -0.295993   -0.316136     -0.320353     0.896287   -0.0602685
 0.0       0.0       0.0         0.0         0.0        0.0         0.0        0.0       0.472341       0.197517    0.44444     0.444223   0.12067     0.000972882   0.370198     0.420233   -0.360152
 0.0       0.0       0.0         0.0         0.0        0.0         0.0        0.0       0.0            0.132166   -0.184599    0.466758  -0.948501   -0.254036     -0.522277     0.814787   -0.00530308
 0.0       0.0       0.0         0.0         0.0        0.0         0.0        0.0       0.0        …  -0.234885    0.089622    0.559229   0.300346    0.068095      0.475377    -0.182851   -0.452322
 0.0       0.0       0.0         0.0         0.0        0.0         0.0        0.0       0.0            0.899276    0.66222     1.02909    0.235373   -0.505155      0.166948     0.0973174  -0.631181
 0.0       0.0       0.0         0.0         0.0        0.0         0.0        0.0       0.0           -0.855794   -0.397243   -0.726078   0.0454122  -0.527535      0.758777    -0.426111   -0.551945
 0.0       0.0       0.0         0.0         0.0        0.0         0.0        0.0       0.0            0.0         0.586901    0.155515  -0.0749635   0.402561     -0.677637     0.613162    0.389598
 0.0       0.0       0.0         0.0         0.0        0.0         0.0        0.0       0.0            0.0         0.0        -1.21729    0.0188052  -0.794731      1.37346     -0.347711   -0.661839
 0.0       0.0       0.0         0.0         0.0        0.0         0.0        0.0       0.0        …   0.0         0.0         0.0       -0.991214   -0.328793     -0.335551     0.207845    0.357929
 0.0       0.0       0.0         0.0         0.0        0.0         0.0        0.0       0.0            0.0         0.0         0.0        0.0         0.603902     -0.00100478   0.892915    0.390133
 0.0       0.0       0.0         0.0         0.0        0.0         0.0        0.0       0.0            0.0         0.0         0.0        0.0         0.0          -0.393145    -1.33191     0.0467669
 0.0       0.0       0.0         0.0         0.0        0.0         0.0        0.0       0.0            0.0         0.0         0.0        0.0         0.0           0.0         -1.54181    -0.369156
 0.0       0.0       0.0         0.0         0.0        0.0         0.0        0.0       0.0            0.0         0.0         0.0        0.0         0.0           0.0          0.0         0.187867

julia> @btime RecursiveFactorization.lu($CA)
  971.300 ns (2 allocations: 3.48 KiB)
LU{Float64, ComponentMatrix{Float64}}
L factor:
20×20 Matrix{Float64}:
 1.0         0.0         0.0         0.0           0.0        0.0        0.0         0.0         0.0        …  0.0         0.0        0.0        0.0        0.0        0.0        0.0       0.0       0.0
 0.211102    1.0         0.0         0.0           0.0        0.0        0.0         0.0         0.0           0.0         0.0        0.0        0.0        0.0        0.0        0.0       0.0       0.0
 0.199294    0.68446     1.0         0.0           0.0        0.0        0.0         0.0         0.0           0.0         0.0        0.0        0.0        0.0        0.0        0.0       0.0       0.0
 0.0981146   0.504114    0.494411    1.0           0.0        0.0        0.0         0.0         0.0           0.0         0.0        0.0        0.0        0.0        0.0        0.0       0.0       0.0
 0.245132   -0.0390206  -0.0402047   0.879783      1.0        0.0        0.0         0.0         0.0           0.0         0.0        0.0        0.0        0.0        0.0        0.0       0.0       0.0
 0.882369    0.369548    0.0229027   0.208464      0.240296   1.0        0.0         0.0         0.0        …  0.0         0.0        0.0        0.0        0.0        0.0        0.0       0.0       0.0
 0.519119   -0.0143554   0.15399     0.807994      0.139888  -0.830161   1.0         0.0         0.0           0.0         0.0        0.0        0.0        0.0        0.0        0.0       0.0       0.0
 0.719704    0.272921    0.589937    0.0470892    -0.302887   0.492686   0.252247    1.0         0.0           0.0         0.0        0.0        0.0        0.0        0.0        0.0       0.0       0.0
 0.444703    0.748184    0.892587   -0.0674539    -0.422343   0.4746     0.313037    0.316719    1.0           0.0         0.0        0.0        0.0        0.0        0.0        0.0       0.0       0.0
 0.205642    0.763844   -0.0519715   0.624348      0.737099  -0.823249   0.751266   -0.968142   -0.150667      0.0         0.0        0.0        0.0        0.0        0.0        0.0       0.0       0.0
 0.861231   -0.0500001  -0.160726    0.493283      0.382889   0.544949   0.367403    0.0514734  -0.332622   …  0.0         0.0        0.0        0.0        0.0        0.0        0.0       0.0       0.0
 0.988454    0.0131208   0.616325    0.270501     -0.843687  -0.260494   0.59309     0.139343   -0.829131      1.0         0.0        0.0        0.0        0.0        0.0        0.0       0.0       0.0
 0.846752    0.261747    0.413092    0.697295     -0.171497  -0.350981   0.287617   -0.0480768   0.601006      0.0310679   1.0        0.0        0.0        0.0        0.0        0.0       0.0       0.0
 0.804111    0.393973    0.741251    0.000741975  -0.935047   0.61989    0.0814095   0.750294   -0.0963975     0.371313    0.453647   1.0        0.0        0.0        0.0        0.0       0.0       0.0
 0.602739    0.29331     0.442008    0.105678     -0.87439    0.28299    0.287128    0.857947   -0.732191      0.530426   -0.509723   0.605711   1.0        0.0        0.0        0.0       0.0       0.0
 0.506056    0.764883    0.348271    0.542409      0.22464   -0.151427   0.617552   -0.768915    0.0140466  …  0.501406    0.576905   0.549992  -0.257272   1.0        0.0        0.0       0.0       0.0
 0.9553     -0.0939602  -0.172728    0.15381      -0.386436   0.171673   0.500983    0.0535261  -0.619998      0.584394   -0.877756  -0.246671   0.664617   0.37898    1.0        0.0       0.0       0.0
 0.845161    0.813056    0.117507    0.201667      0.163245  -0.538107   0.833325   -0.451238    0.079386      0.316022    0.21245   -0.109802   0.0780122  0.256051   0.799157   1.0       0.0       0.0
 0.792648    0.811241    0.555038    0.0463599    -0.878346   0.91041   -0.096382    0.790969   -0.408181      0.0683267  -0.331457   0.103808   0.52856    0.0347386  0.549886  -0.987399  1.0       0.0
 0.111179    0.802354    0.0954193   0.182611      0.715776   0.265278  -0.193452   -0.141881   -0.127051      0.123545    0.298874   0.841487   0.0153677  0.69162    0.182688  -0.116982  0.363034  1.0
U factor:
20×20 Matrix{Float64}:
 0.999558  0.190124  0.332883    0.576808    0.86233    0.0353636   0.963261   0.835241  0.237633   …   0.22654     0.834873    0.987072   0.704351    0.459602      0.193632     0.327695    0.248773
 0.0       0.949465  0.0379463   0.0244109  -0.0556951  0.202853    0.262819   0.757072  0.0108968      0.195099    0.289672    0.726778   0.577808    0.115113      0.219081     0.355078    0.0869451
 0.0       0.0       0.888814   -0.112111    0.74368    0.250033   -0.285749  -0.196446  0.193236       0.793046   -0.259109   -0.379195  -0.107127    0.261578      0.547022    -0.188109    0.0664724
 0.0       0.0       0.0         0.641664   -0.184754   0.699157    0.511894   0.245242  0.0727618      0.301722    0.0385283   0.481747   0.515392    0.665369      0.274596     0.197628    0.478068
 0.0       0.0       0.0         0.0         0.762965   0.167463   -0.266378   0.362912  0.169522       0.378146    0.294834    0.287167   0.336192    0.0463076     0.544484     0.137148   -0.245698
 0.0       0.0       0.0         0.0         0.0        0.672803   -0.266677  -0.884052  0.0114975  …   0.168219   -0.0959106  -1.15285   -0.143369    0.34734       0.0979505   -0.354278    0.0646805
 0.0       0.0       0.0         0.0         0.0        0.0        -0.968065  -0.76473   0.393264      -0.347029   -0.495136   -1.82994   -0.475784    0.247682     -0.297865     0.215312    0.493923
 0.0       0.0       0.0         0.0         0.0        0.0         0.0        1.02596   0.352547       0.0595848  -0.0792222   1.05333   -0.295993   -0.316136     -0.320353     0.896287   -0.0602685
 0.0       0.0       0.0         0.0         0.0        0.0         0.0        0.0       0.472341       0.197517    0.44444     0.444223   0.12067     0.000972882   0.370198     0.420233   -0.360152
 0.0       0.0       0.0         0.0         0.0        0.0         0.0        0.0       0.0            0.132166   -0.184599    0.466758  -0.948501   -0.254036     -0.522277     0.814787   -0.00530308
 0.0       0.0       0.0         0.0         0.0        0.0         0.0        0.0       0.0        …  -0.234885    0.089622    0.559229   0.300346    0.068095      0.475377    -0.182851   -0.452322
 0.0       0.0       0.0         0.0         0.0        0.0         0.0        0.0       0.0            0.899276    0.66222     1.02909    0.235373   -0.505155      0.166948     0.0973174  -0.631181
 0.0       0.0       0.0         0.0         0.0        0.0         0.0        0.0       0.0           -0.855794   -0.397243   -0.726078   0.0454122  -0.527535      0.758777    -0.426111   -0.551945
 0.0       0.0       0.0         0.0         0.0        0.0         0.0        0.0       0.0            0.0         0.586901    0.155515  -0.0749635   0.402561     -0.677637     0.613162    0.389598
 0.0       0.0       0.0         0.0         0.0        0.0         0.0        0.0       0.0            0.0         0.0        -1.21729    0.0188052  -0.794731      1.37346     -0.347711   -0.661839
 0.0       0.0       0.0         0.0         0.0        0.0         0.0        0.0       0.0        …   0.0         0.0         0.0       -0.991214   -0.328793     -0.335551     0.207845    0.357929
 0.0       0.0       0.0         0.0         0.0        0.0         0.0        0.0       0.0            0.0         0.0         0.0        0.0         0.603902     -0.00100478   0.892915    0.390133
 0.0       0.0       0.0         0.0         0.0        0.0         0.0        0.0       0.0            0.0         0.0         0.0        0.0         0.0          -0.393145    -1.33191     0.0467669
 0.0       0.0       0.0         0.0         0.0        0.0         0.0        0.0       0.0            0.0         0.0         0.0        0.0         0.0           0.0         -1.54181    -0.369156
 0.0       0.0       0.0         0.0         0.0        0.0         0.0        0.0       0.0            0.0         0.0         0.0        0.0         0.0           0.0          0.0         0.187867
```