### PR TITLE
Don't use syntactic sugar only available in julia >= 16

### DIFF
--- a/src/compat/diffeqbase.jl
+++ b/src/compat/diffeqbase.jl
@@ -1,2 +1,2 @@
 # Can we figure out how to get rid of this?
-(p::DiffEqBase.DefaultLinSolve)(x, A::ComponentMatrix, b, update_matrix=false; tol=nothing, kwargs...) = p(x, getdata(A), b, update_matrix; tol, kwargs...)
+(p::DiffEqBase.DefaultLinSolve)(x, A::ComponentMatrix, b, update_matrix=false; tol=nothing, kwargs...) = p(x, getdata(A), b, update_matrix; tol=tol, kwargs...)


### PR DESCRIPTION
The current project.toml claims compatibility for julia "1".

The function call "p(x, getdata(A), b, update_matrix; tol, kwargs...)"
as shorthand for  "p(x, getdata(A), b, update_matrix; tol=tol, kwargs...)"
only became valid in Julia 1.5.  Compare
https://docs.julialang.org/en/v1.4/manual/functions/#Keyword-Arguments-1
with
https://docs.julialang.org/en/v1.5/manual/functions/#Keyword-Arguments
which adds the paragraph starting with "When a bare identifier or dot
expression occurs after a semicolon,"