### PR TITLE
changing sciml base indexing and adding test

### DIFF
--- a/src/compat/scimlbase.jl
+++ b/src/compat/scimlbase.jl
@@ -2,11 +2,12 @@
 
 # Plotting stuff
 function SciMLBase.getsyms(sol::SciMLBase.AbstractODESolution{T,N,C}) where {T,N,C<:AbstractVector{<:ComponentArray}}
-    if SciMLBase.has_syms(sol.prob.f)
-        return sol.prob.f.syms
-    else
-        return labels(sol.u[1])
-    end
+#    if SciMLBase.has_syms(sol.prob.f)
+#       return sol.prob.f.syms
+#    else
+#        return labels(sol.u[1])
+#    end
+    keys(sol.prob.u0)
 end
 
 # A little bit of type piracy. Should probably make this a PR to DiffEqBase

--- a/test/diffeq_test/diffeq_tests.jl
+++ b/test/diffeq_test/diffeq_tests.jl
@@ -123,3 +123,22 @@ end
         @test (ctime - ltime)/ltime < 0.05
     end
 end
+
+@testset "symbolic-indexing" begin
+    function lotka!(D, u, p, t; f=0)
+        @unpack α, β, γ, δ = p
+        @unpack x, y = u
+    
+        D.x =  α*x - β*x*y
+        D.y = -γ*y + δ*x*y
+        return nothing
+    end
+    
+    lotka_p = (α=2/3, β=4/3, γ=1.0, δ=1.0)
+    lotka_ic = ComponentArray(x=1.0, y=1.0)
+    tspan = (0.0,10.0)
+    lotka_prob = ODEProblem(lotka!, lotka_ic, tspan, lotka_p)
+    sol = solve(lotka_prob, Tsit5(), saveat=1.0)
+    @test length(sol[:x]) == 11
+    @test typeof(sol[:x]) == Vector{Float64}
+end


### PR DESCRIPTION
I was unable to symbolically index the solutions to differential equation solutions. I've changed `SciMLBase.getsyms` method to fix this and adding some test. 

The plotting functionality is also maintained (lines are labelled with the correct symbols). I don't know how to test this though. It's still not possible to do something like `plot(sol, vars=(:x,))`.