### PR TITLE
way faster constructor

### DIFF
--- a/src/componentarray.jl
+++ b/src/componentarray.jl
@@ -138,12 +138,18 @@ make_carray_args(::NamedTuple{(), Tuple{}}) = (Any[], FlatAxis())
 make_carray_args(::Type{T}, ::NamedTuple{(), Tuple{}}) where {T} = (T[], FlatAxis())
 function make_carray_args(nt)
     data, ax = make_carray_args(Vector, nt)
-    data = length(data)==1 ? [data[1]] : reduce(vcat, data)
+    data = length(data)==1 ? [data[1]] : eltype(data) == Any ? reduce(vcat, data) : data
     return (data, ax)
 end
 make_carray_args(::Type{T}, nt) where {T} = make_carray_args(Vector{T}, nt)
 function make_carray_args(A::Type{<:AbstractArray}, nt)
-    data, idx = make_idx([], nt, 0)
+    init = try
+        T = recursive_type(nt)
+        isa(T, Type) ? T[] : []
+    catch
+        []
+    end
+    data, idx = make_idx(init, nt, 0)
     return (A(data), Axis(idx))
 end
 

--- a/src/componentarray.jl
+++ b/src/componentarray.jl
@@ -62,7 +62,6 @@ ComponentArray{T}(nt::NamedTuple) where T = ComponentArray(make_carray_args(T, n
 ComponentArray{T}(::NamedTuple{(), Tuple{}}) where T = ComponentArray(T[], (FlatAxis(),))
 ComponentArray(nt::Union{NamedTuple, AbstractDict}) = ComponentArray(make_carray_args(nt)...)
 ComponentArray(::NamedTuple{(), Tuple{}}) = ComponentArray(Any[], (FlatAxis(),))
-#ComponentArray(d::AbstractDict) = ComponentArray(NamedTuple{Tuple(keys(d))}(values(d)))
 ComponentArray{T}(;kwargs...) where T = ComponentArray{T}((;kwargs...))
 ComponentArray(;kwargs...) = ComponentArray((;kwargs...))
 

--- a/src/componentarray.jl
+++ b/src/componentarray.jl
@@ -138,20 +138,19 @@ make_carray_args(::NamedTuple{(), Tuple{}}) = (Any[], FlatAxis())
 make_carray_args(::Type{T}, ::NamedTuple{(), Tuple{}}) where {T} = (T[], FlatAxis())
 function make_carray_args(nt)
     data, ax = make_carray_args(Vector, nt)
-    data = length(data)==1 ? [data[1]] : eltype(data) == Any ? reduce(vcat, data) : data
+    data = length(data)==1 ? [data[1]] : data
     return (data, ax)
 end
 make_carray_args(::Type{T}, nt) where {T} = make_carray_args(Vector{T}, nt)
 function make_carray_args(A::Type{<:AbstractArray}, nt)
-    init = try
-        T = recursive_type(nt)
-        isprimitivetype(T) ? T[] : []
-    catch
-        []
-    end
+    T = recursive_eltype(nt)
+    init = _isprimitivetype(T) ? T[] : []
     data, idx = make_idx(init, nt, 0)
     return (A(data), Axis(idx))
 end
+
+_isprimitivetype(::Type{<:Union{T, Nothing, Missing}}) where {T} = isprimitivetype(T)
+_isprimitivetype(T) = isprimitivetype(T)
 
 # Builds up data vector and returns appropriate AbstractAxis type for each input type
 function make_idx(data, nt::NamedTuple, last_val)

--- a/src/componentarray.jl
+++ b/src/componentarray.jl
@@ -143,13 +143,13 @@ end
 make_carray_args(::Type{T}, nt) where {T} = make_carray_args(Vector{T}, nt)
 function make_carray_args(A::Type{<:AbstractArray}, nt)
     T = recursive_eltype(nt)
-    init = _isprimitivetype(T) ? T[] : []
+    init = _isbitstype(T) ? T[] : []
     data, idx = make_idx(init, nt, 0)
     return (A(data), Axis(idx))
 end
 
-_isprimitivetype(::Type{<:Union{T, Nothing, Missing}}) where {T} = isprimitivetype(T)
-_isprimitivetype(T) = isprimitivetype(T)
+_isbitstype(::Type{<:Union{T, Nothing, Missing}}) where {T} = isbitstype(T)
+_isbitstype(T) = isbitstype(T)
 
 # Builds up data vector and returns appropriate AbstractAxis type for each input type
 function make_idx(data, nt::Union{NamedTuple, AbstractDict}, last_val)

--- a/src/componentarray.jl
+++ b/src/componentarray.jl
@@ -145,7 +145,7 @@ make_carray_args(::Type{T}, nt) where {T} = make_carray_args(Vector{T}, nt)
 function make_carray_args(A::Type{<:AbstractArray}, nt)
     init = try
         T = recursive_type(nt)
-        isa(T, Type) ? T[] : []
+        isprimitivetype(T) ? T[] : []
     catch
         []
     end

--- a/src/componentarray.jl
+++ b/src/componentarray.jl
@@ -153,7 +153,7 @@ _isprimitivetype(::Type{<:Union{T, Nothing, Missing}}) where {T} = isprimitivety
 _isprimitivetype(T) = isprimitivetype(T)
 
 # Builds up data vector and returns appropriate AbstractAxis type for each input type
-function make_idx(data, nt::Union{NamedTuple, Dict}, last_val)
+function make_idx(data, nt::Union{NamedTuple, AbstractDict}, last_val)
     len = recursive_length(nt)
     kvs = []
     lv = 0

--- a/src/componentarray.jl
+++ b/src/componentarray.jl
@@ -60,9 +60,9 @@ end
 # Entry from NamedTuple, Dict, or kwargs
 ComponentArray{T}(nt::NamedTuple) where T = ComponentArray(make_carray_args(T, nt)...)
 ComponentArray{T}(::NamedTuple{(), Tuple{}}) where T = ComponentArray(T[], (FlatAxis(),))
-ComponentArray(nt::NamedTuple) = ComponentArray(make_carray_args(nt)...)
+ComponentArray(nt::Union{NamedTuple, AbstractDict}) = ComponentArray(make_carray_args(nt)...)
 ComponentArray(::NamedTuple{(), Tuple{}}) = ComponentArray(Any[], (FlatAxis(),))
-ComponentArray(d::AbstractDict) = ComponentArray(NamedTuple{Tuple(keys(d))}(values(d)))
+#ComponentArray(d::AbstractDict) = ComponentArray(NamedTuple{Tuple(keys(d))}(values(d)))
 ComponentArray{T}(;kwargs...) where T = ComponentArray{T}((;kwargs...))
 ComponentArray(;kwargs...) = ComponentArray((;kwargs...))
 
@@ -138,7 +138,7 @@ make_carray_args(::NamedTuple{(), Tuple{}}) = (Any[], FlatAxis())
 make_carray_args(::Type{T}, ::NamedTuple{(), Tuple{}}) where {T} = (T[], FlatAxis())
 function make_carray_args(nt)
     data, ax = make_carray_args(Vector, nt)
-    data = length(data)==1 ? [data[1]] : data
+    data = length(data)==1 ? [data[1]] : map(identity, data)
     return (data, ax)
 end
 make_carray_args(::Type{T}, nt) where {T} = make_carray_args(Vector{T}, nt)
@@ -153,7 +153,7 @@ _isprimitivetype(::Type{<:Union{T, Nothing, Missing}}) where {T} = isprimitivety
 _isprimitivetype(T) = isprimitivetype(T)
 
 # Builds up data vector and returns appropriate AbstractAxis type for each input type
-function make_idx(data, nt::NamedTuple, last_val)
+function make_idx(data, nt::Union{NamedTuple, Dict}, last_val)
     len = recursive_length(nt)
     kvs = []
     lv = 0

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -42,3 +42,9 @@ recursive_length(a::AbstractArray{T,N}) where {T<:Number,N} = length(a)
 recursive_length(a::AbstractArray) = recursive_length.(a) |> sum
 recursive_length(nt::NamedTuple) = values(nt) .|> recursive_length |> sum
 recursive_length(::Union{Nothing, Missing}) = 1
+
+# Find the highest element type
+recursive_type(nt::NamedTuple) = mapreduce(recursive_type, promote_type, nt)
+recursive_type(x::Vector{Any}) = mapreduce(recursive_type, promote_type, x)
+recursive_type(x::Number) = typeof(x)
+recursive_type(::AbstractArray{T,N})  where {T<:Number, N}= T

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -48,5 +48,4 @@ recursive_eltype(nt::NamedTuple) = mapreduce(recursive_eltype, promote_type, nt)
 recursive_eltype(x::Vector) = mapreduce(recursive_eltype, promote_type, x)
 recursive_eltype(x::Dict) = mapreduce(recursive_eltype, promote_type, values(x))
 recursive_eltype(::AbstractArray{T,N})  where {T<:Number, N}= T
-recursive_eltype(x::Number) = typeof(x)
-recursive_eltype(x) = Base.eltypeof(x)
+recursive_eltype(x) = typeof(x)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -44,7 +44,9 @@ recursive_length(nt::NamedTuple) = values(nt) .|> recursive_length |> sum
 recursive_length(::Union{Nothing, Missing}) = 1
 
 # Find the highest element type
-recursive_type(nt::NamedTuple) = mapreduce(recursive_type, promote_type, nt)
-recursive_type(x::Vector{Any}) = mapreduce(recursive_type, promote_type, x)
-recursive_type(x::Number) = typeof(x)
-recursive_type(::AbstractArray{T,N})  where {T<:Number, N}= T
+recursive_eltype(nt::NamedTuple) = mapreduce(recursive_eltype, promote_type, nt)
+recursive_eltype(x::Vector) = mapreduce(recursive_eltype, promote_type, x)
+recursive_eltype(x::Dict) = mapreduce(recursive_eltype, promote_type, values(x))
+recursive_eltype(::AbstractArray{T,N})  where {T<:Number, N}= T
+recursive_eltype(x::Number) = typeof(x)
+recursive_eltype(x) = Base.eltypeof(x)


### PR DESCRIPTION
Maybe I misunderstood, `reduce` looks like it's for restoring the type. If the type is determined at the beginning, then there is no need to call `reduce`.

```julia
julia> data_1 = rand(30,20);

julia> data_2 = rand(30,20);

julia> @benchmark ComponentArray(a = $data_1, b = $data_2) # Original
BenchmarkTools.Trial: 8075 samples with 1 evaluation.
 Range (min … max):  372.000 μs …   5.988 ms  ┊ GC (min … max):  0.00% … 90.97%
 Time  (median):     451.300 μs               ┊ GC (median):     0.00%
 Time  (mean ± σ):   615.631 μs ± 819.858 μs  ┊ GC (mean ± σ):  25.07% ± 16.55%

  ██▄▃▁                                                     ▁ ▁ ▂
  █████▇▆▅▃▅▄▄▄▁▃▁▃▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▅████ █
  372 μs        Histogram: log(frequency) by time          5 ms <

 Memory estimate: 2.96 MiB, allocs estimate: 2442.

julia>  @benchmark ComponentArray(a = $data_1, b = $data_2) # This PR
BenchmarkTools.Trial: 10000 samples with 1 evaluation.
 Range (min … max):   9.400 μs …  1.983 ms  ┊ GC (min … max): 0.00% … 98.03%
 Time  (median):     11.100 μs              ┊ GC (median):    0.00%
 Time  (mean ± σ):   13.263 μs ± 49.256 μs  ┊ GC (mean ± σ):  9.68% ±  2.60%

     ▅▆▇▇█▆▆▅▅▂▂▁▁▂▁▂▃▂▂▂▃▁▂▁▂▁▁                              ▂
  ▂▃███████████████████████████████▇▇▇▅▆▇▇▆▆▆▇▆▆▆▆▃▄▅▅▅▅▄▆▅▄▅ █
  9.4 μs       Histogram: log(frequency) by time      22.7 μs <

 Memory estimate: 32.77 KiB, allocs estimate: 43.
```
