### PR TITLE
Add constructor for GPUArrays

### DIFF
--- a/src/compat/gpuarrays.jl
+++ b/src/compat/gpuarrays.jl
@@ -64,3 +64,10 @@ for (fname, op) in [(:sum, :(Base.add_sum)), (:prod, :(Base.mul_prod)),
             GPUArrays.mapreducedim!(f, $(op), getdata(r), getdata(A); init=neutral_element($(op), T))
     end
 end
+
+function ComponentArray(nt::NamedTuple{names,<:Tuple{Vararg{GPUArrays.AbstractGPUArray}}}) where {names}
+    T = promote_type(map(eltype, nt)...)
+    nt = map(Base.Fix1(broadcast, T), nt)
+    G = typeof(first(nt))
+    return GPUArrays.adapt(G, ComponentArray(NamedTuple{names}(map(collect, nt))))
+end

--- a/src/compat/gpuarrays.jl
+++ b/src/compat/gpuarrays.jl
@@ -65,9 +65,9 @@ for (fname, op) in [(:sum, :(Base.add_sum)), (:prod, :(Base.mul_prod)),
     end
 end
 
-function ComponentArray(nt::NamedTuple{names,<:Tuple{Vararg{GPUArrays.AbstractGPUArray}}}) where {names}
+function ComponentArray(nt::NamedTuple{names,<:Tuple{Vararg{Union{GPUArrays.AbstractGPUArray,GPUComponentArray}}}}) where {names}
     T = recursive_eltype(nt)
     nt = map(Base.Fix1(broadcast, T), nt)
     G = typeof(first(nt))
-    return GPUArrays.adapt(G, ComponentArray(NamedTuple{names}(map(collect, nt))))
+    return GPUArrays.adapt(G, ComponentArray(NamedTuple{names}(map(GPUArrays.adapt(Array), nt))))
 end

--- a/src/compat/gpuarrays.jl
+++ b/src/compat/gpuarrays.jl
@@ -66,7 +66,7 @@ for (fname, op) in [(:sum, :(Base.add_sum)), (:prod, :(Base.mul_prod)),
 end
 
 function ComponentArray(nt::NamedTuple{names,<:Tuple{Vararg{GPUArrays.AbstractGPUArray}}}) where {names}
-    T = promote_type(map(eltype, nt)...)
+    T = recursive_eltype(nt)
     nt = map(Base.Fix1(broadcast, T), nt)
     G = typeof(first(nt))
     return GPUArrays.adapt(G, ComponentArray(NamedTuple{names}(map(collect, nt))))

--- a/src/compat/gpuarrays.jl
+++ b/src/compat/gpuarrays.jl
@@ -67,6 +67,7 @@ end
 
 function ComponentArray(nt::NamedTuple{names,<:Tuple{Vararg{Union{GPUArrays.AbstractGPUArray,GPUComponentArray}}}}) where {names}
     T = recursive_eltype(nt)
-    G = Base.typename(typeof(getdata(first(nt))))
+    gpuarray = getdata(first(nt))
+    G = Base.typename(typeof(gpuarray)).wrapper  # SciMLBase.parameterless_type(gpuarray)
     return GPUArrays.adapt(G, ComponentArray(NamedTuple{names}(map(GPUArrays.adapt(Array{T}), nt))))
 end

--- a/src/compat/gpuarrays.jl
+++ b/src/compat/gpuarrays.jl
@@ -67,7 +67,6 @@ end
 
 function ComponentArray(nt::NamedTuple{names,<:Tuple{Vararg{Union{GPUArrays.AbstractGPUArray,GPUComponentArray}}}}) where {names}
     T = recursive_eltype(nt)
-    nt = map(Base.Fix1(broadcast, T), nt)
-    G = typeof(first(nt))
-    return GPUArrays.adapt(G, ComponentArray(NamedTuple{names}(map(GPUArrays.adapt(Array), nt))))
+    G = Base.typename(typeof(getdata(first(nt))))
+    return GPUArrays.adapt(G, ComponentArray(NamedTuple{names}(map(GPUArrays.adapt(Array{T}), nt))))
 end


### PR DESCRIPTION
Currently constructing ComponentArrays on the GPU with for example `ComponentArray(a=CUDA.ones(2,3), b=CUDA.ones(4,5))` fails with an error.

```
ERROR: CuArray only supports element types that are stored inline
```

This fails because constructing the ComponentArray causes the creation of an array of arrays, which is not possible on the GPU. This happens in the `pushcat!` call at line 179 in componentarray.jl:

https://github.com/jonniedie/ComponentArrays.jl/blob/a7d6f7d126c5aeb711b65cf74eff8f8cbbeca5d0/src/componentarray.jl#L178-L182

This pull request fixes the issue by constructing the ComponentArray on the CPU and moving it back to the GPU afterwards.

Fixes #158. Needed for SciML/NeuralPDE.jl#594.