### PR TITLE
Change Adjoints to be ComponentArrays

### DIFF
--- a/src/linear_algebra.jl
+++ b/src/linear_algebra.jl
@@ -43,3 +43,17 @@ for op in [:*, :\, :/]
         end
     end
 end
+
+
+for op in [:adjoint, :transpose]
+    @eval begin
+        function LinearAlgebra.$op(M::ComponentMatrix{T,A,Tuple{Ax1,Ax2}}) where {T,A,Ax1,Ax2}
+            data = $op(getdata(M))
+            return ComponentArray(data, (Ax2(), Ax1())[1:ndims(data)]...)
+        end
+
+        function LinearAlgebra.$op(M::ComponentVector{T,A,Tuple{Ax1}}) where {T,A,Ax1}
+            return ComponentMatrix($op(getdata(M)), FlatAxis(), Ax1())
+        end
+    end
+end


### PR DESCRIPTION
This PR aims to avoid issues like:
```
using ComponentArrays
A = ComponentMatrix(ones(2, 2), Axis(:a, :b), FlatAxis())
A[:b, :] # works
A'[:, :b] # fails!
```
by wrapping adjoint operations in the underlying data of the ComponentArray structure.

By not having to care about adjoints of ComponentArray, we arguably also reduce overall cognitive load.