### PR TITLE
Add utility function to reorder ComponentArrays

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -50,3 +50,16 @@ recursive_eltype(x::Vector{Any}) = isempty(x) ? Base.Bottom : mapreduce(recursiv
 recursive_eltype(x::Dict) = isempty(x) ? Base.Bottom : mapreduce(recursive_eltype, promote_type, values(x))
 recursive_eltype(::AbstractArray{T,N}) where {T<:Number, N} = T
 recursive_eltype(x) = typeof(x)
+
+
+function reorder_as(prototype::ComponentArray, input::ComponentArray)
+    @assert size(prototype) == size(input) "Incompatible sizes: $(size(prototype)) and $(size(input))"
+    @inline getslice(::AbstractAxis{nothing}) = (:,)
+    @inline getslice(::AbstractAxis{:}) = (:,)
+    @inline getslice(::AbstractAxis{IdxMap}) where {IdxMap} = IdxMap
+    result = ComponentArray(getdata(input), getaxes(prototype)...)
+    for slices in Base.product(getslice.(getaxes(prototype))...)
+        result[slices...] = input[slices...]
+    end
+    return result
+end


### PR DESCRIPTION
###  Summary
This PR adds a utility function that reorders ComponentArrays as per another prototype.

### Example Output
```julia
a = ComponentVector(a=1, b=2)
b = ComponentVector(b=10, a=20)
reoder_as(a, b)
```
gives
```
ComponentVector(a=20, b=10)
```
### Motivation and Example Usages:
Suppose we want to compute the dot product between two ComponentVectors, while caring about the order of the elements, as defined by the symbols of the ComponentVectorAxis.

That is we want `my_dot(ComponentVector(a=1, b=0), ComponentVector(b=0, a=1)` to give `a1*a2 + b1*b2=1*1 + 0*0=0` instead of `dot(collect(arg1), collect(arg2)` that it normally does.

This utility function allows to do this in a generic way like following:
```julia
my_dot(v1::ComponentArray, v2 ComponentArray) = (v1, reorder_as(v1, v2)))
```