### PR TITLE
Consider redacting printing of Axis types

### DIFF
--- a/src/show.jl
+++ b/src/show.jl
@@ -1,4 +1,4 @@
-# Show AbstractAxis types
+# Show AbstractAxis instances
 Base.show(io::IO, ::MIME"text/plain", ::Axis{IdxMap}) where IdxMap = print(io, "Axis$IdxMap")
 Base.show(io::IO, ::Axis{IdxMap}) where IdxMap = print(io, "Axis$IdxMap")
 
@@ -22,7 +22,19 @@ Base.show(io::IO, ::ViewAxis{Inds, IdxMap, <:Ax}) where {Inds, IdxMap, Ax} =
 Base.show(io::IO, ::ViewAxis{Inds, IdxMap, <:NullorFlatAxis}) where {Inds, IdxMap} = 
     print(io, Inds)
 
+# Show reducted Axis types to avoid excessive stacktraces
+Base.show(io::IO, ::Type{Axis{IdxMap}}) where {IdxMap} = print(io, "Axis{...}")
+Base.show(io::IO, ::Type{FlatAxis}) = print(io, "FlatAxis")
+Base.show(io::IO, ::Type{NullAxis}) = print(io, "NullAxis")
+function Base.show(io::IO, ::Type{PartitionedAxis{PartSz,IdxMap,Ax}}) where {PartSz,IdxMap,Ax}
+    return print(io, "PartitionedAxis{$PartSz, {...}, $Ax}")
+end
+Base.show(io::IO, ::Type{ShapedAxis{Shape,IdxMap}}) where {Shape,IdxMap} = print(io, "ShapedAxis($Shape, {...})")
+Base.show(io::IO, ::Type{ViewAxis{Inds,IdxMap,Ax}}) where {Inds,IdxMap,Ax} = print(io, "ViewAxis{$Inds, {...}, $Ax)")
+
 Base.show(io::IO, ci::ComponentIndex) = print(io, "ComponentIndex($(ci.idx), $(ci.ax))")
+
+
 
 
 # Show ComponentArrays


### PR DESCRIPTION
This PR reduces the very long stacktraces that can sometimes occur with ComponentArrays, by having by default a reducted form of `Base.show` for Axis types.

Example:
```julia
ERROR: MethodError: no method matching h(::ComponentMatrix{Float64, Matrix{Float64}, Tuple{Axis{...}, FlatAxis}})
Closest candidates are:
  h() at REPL[14]:1
Stacktrace:
 [1] top-level scope
   @ REPL[15]:1
```
now gives
```julia
ERROR: MethodError: no method matching h(::ComponentMatrix{Float64, Matrix{Float64}, Tuple{Axis{...}, FlatAxis}})
Closest candidates are:
  h() at REPL[2]:1
Stacktrace:
 [1] top-level scope
   @ REPL[3]:1
```julia
instead of
```
ERROR: MethodError: no method matching h(::ComponentMatrix{Float64, Matrix{Float64}, Tuple{Axis{(first = 1, second = 2, third = 3, fourth = 4)}, FlatAxis}})
Closest candidates are:
  h() at REPL[2]:1
Stacktrace:
 [1] top-level scope
   @ REPL[3]:1
```