### PR TITLE
Fix indexing issues #175 and #174

### DIFF
--- a/src/array_interface.jl
+++ b/src/array_interface.jl
@@ -123,7 +123,11 @@ Base.@propagate_inbounds Base.maybeview(x::ComponentArray, idx...) = _getindex(B
     inds = map(i -> i.idx, ci)
     axs = map(i -> i.ax, ci)
     axs = remove_nulls(axs...)
-    return :(ComponentArray(index_fun(getdata(x), $inds...), $axs...))
+    if isa(axs, Tuple{})
+        return :(index_fun(getdata(x), $inds...))
+    else
+        return :(ComponentArray(index_fun(getdata(x), $inds...), $axs...))
+    end
 end
 
 @generated function _setindex!(x::ComponentArray, v, idx...)

--- a/src/axis.jl
+++ b/src/axis.jl
@@ -170,7 +170,7 @@ function Base.getindex(ax::AbstractAxis, syms::Union{NTuple{N,Symbol}, <:Abstrac
         _maybe_view_axis(first_index:last_index, ax)
     end
     new_ax = Axis(NamedTuple(syms .=> new_axs))
-    return ComponentIndex(reduce(vcat, inds), new_ax)
+    return ComponentIndex(vcat(inds...), new_ax)
 end
 
 _maybe_view_axis(inds, ax::Axis) = ViewAxis(inds, ax)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -176,7 +176,10 @@ end
     @test ca.c == ComponentArray(c)
     @test ca2.b[1].a.a == 20.0
 
-    @test ca[:a] == ca["a"] == ca.a
+    @test ca[:a] == ca["a"] == ca.a == ca[[:a]][1]
+    @test ca[[:a]] isa ComponentVector  # Issue 175
+    @test ca[Symbol[]] == Float64[]  # Issue 174
+    @test length(ca[()]) == 0  # Issue #174
     @test ca[:b] == ca["b"] == ca.b
     @test ca[:c] == ca["c"] == ca.c
 


### PR DESCRIPTION
As described in the title, this PR fixes tow indexing issues (#175 and #174) and adds associated tests.

Note: When indexing with zero a zero length tuple or vector of symbols a vector instead of a componentvector is returned which I find inconsistent. I didn't opt to address this in this PR, as I that it is a result of more fundamental choices regarding `_getindex` and the handling of ComponentVectors with flat axes only. I plan to open a separate issue to discuss these.