### PR TITLE
fix invalidations

### DIFF
--- a/src/axis.jl
+++ b/src/axis.jl
@@ -84,7 +84,7 @@ Axis for creating arrays of `ComponentArray`s
 """
 struct PartitionedAxis{PartSz, IdxMap, Ax<:AbstractAxis{IdxMap}} <: AbstractAxis{IdxMap}
     ax::Ax
-    
+
     function PartitionedAxis(PartSz, ax::AbstractAxis{IdxMap}) where IdxMap
         return new{PartSz,IdxMap,typeof(ax)}(ax)
     end
@@ -202,4 +202,4 @@ Base.getindex(ax::CombinedAxis, i::AbstractArray) = _array_axis(ax)[i]
 
 Base.length(ax::CombinedAxis) = lastindex(ax) - firstindex(ax) + 1
 
-Base.CartesianIndices(ax::Tuple{Vararg{CombinedAxis}}) = CartesianIndices(_array_axis.(ax))
+Base.CartesianIndices(ax::Tuple{CombinedAxis, Vararg{CombinedAxis}}) = CartesianIndices(_array_axis.(ax))


### PR DESCRIPTION
I found quite a few invalidations using the following code with Julia v1.8.3:
```julia
julia> using Pkg; Pkg.activate(temp=true); Pkg.develop("ComponentArrays"); Pkg.add("Trixi")

julia> using SnoopCompileCore; invalidations = @snoopr(using Trixi); using SnoopCompile

julia> length(uinvalidated(invalidations))
1655

julia> trees = invalidation_trees(invalidations)
...
 inserting CartesianIndices(ax::Tuple{Vararg{ComponentArrays.CombinedAxis}}) in ComponentArrays at /home/hendrik/.julia/dev/ComponentArrays/src/axis.jl:205 invalidated:
   backedges: 1: superseding CartesianIndices(indices::R) where {N, R<:Tuple{Vararg{OrdinalRange{Int64, Int64}, N}}} in Base.IteratorsMD at multidimensional.jl:249 with MethodInstance for CartesianIndices(::Tuple{Vararg{Base.OneTo{Int64}}}) (180 children)
   37 mt_cache
...

julia> ascend(trees[end-2].backedges[end])
Choose a call for analysis (q to quit):
^      #vreduce#128(::Int64, ::typeof(LoopVectorization.vreduce), ::typeof(min), ::Array{Int64, 3})
         (::LoopVectorization.var"#vreduce##kw")(::NamedTuple{(:dims,), Tuple{Int64}}, ::typeof(LoopVectorization
           _vminimum(::Array{Int64, 3}, ::Int64)
...
```
The problem is that ComponentArrays.jl overwrites an existing method of `CartesianIndices` for an empty tuple. I fixed that, resulting in
```julia
julia> using Pkg; Pkg.activate(temp=true); Pkg.develop("ComponentArrays"); Pkg.add("Trixi")

julia> using SnoopCompileCore; invalidations = @snoopr(using Trixi); using SnoopCompile

julia> length(uinvalidated(invalidations))
1507

julia> trees = invalidation_trees(invalidations)
```
and the invalidations reported above are gone.