### PR TITLE
No reshape piracy

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ComponentArrays"
 uuid = "b0b7db55-cfe3-40fc-9ded-d10e2dbeff66"
 authors = ["Jonnie Diegelman <47193959+jonniedie@users.noreply.github.com>"]
-version = "0.13.8"
+version = "0.13.9"
 
 [deps]
 ArrayInterface = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"

--- a/src/array_interface.jl
+++ b/src/array_interface.jl
@@ -10,8 +10,6 @@ Base.axes(x::ComponentArray) = CombinedAxis.(getaxes(x), axes(getdata(x)))
 
 Base.reinterpret(::Type{T}, x::ComponentArray, args...) where T = ComponentArray(reinterpret(T, getdata(x), args...), getaxes(x))
 
-Base.reshape(A::AbstractArray, ax::CombinedAxis, axs::Vararg{CombinedAxis}) = reshape(A, last.(_array_axis.((ax, axs...)))...)
-
 ArrayInterface.indices_do_not_alias(::Type{ComponentArray{T,N,A,Axes}}) where {T,N,A,Axes} = ArrayInterface.indices_do_not_alias(A)
 ArrayInterface.instances_do_not_alias(::Type{ComponentArray{T,N,A,Axes}}) where {T,N,A,Axes} = ArrayInterface.instances_do_not_alias(A)
 

--- a/src/array_interface.jl
+++ b/src/array_interface.jl
@@ -10,7 +10,7 @@ Base.axes(x::ComponentArray) = CombinedAxis.(getaxes(x), axes(getdata(x)))
 
 Base.reinterpret(::Type{T}, x::ComponentArray, args...) where T = ComponentArray(reinterpret(T, getdata(x), args...), getaxes(x))
 
-Base.reshape(A::AbstractArray, axs::NTuple{N,<:CombinedAxis}) where {N} = reshape(A, _array_axis.(axs))
+Base.reshape(A::AbstractArray, ax::CombinedAxis, axs::Vararg{CombinedAxis}) = reshape(A, last.(_array_axis.((ax, axs...)))...)
 
 ArrayInterface.indices_do_not_alias(::Type{ComponentArray{T,N,A,Axes}}) where {T,N,A,Axes} = ArrayInterface.indices_do_not_alias(A)
 ArrayInterface.instances_do_not_alias(::Type{ComponentArray{T,N,A,Axes}}) where {T,N,A,Axes} = ArrayInterface.instances_do_not_alias(A)

--- a/src/componentarray.jl
+++ b/src/componentarray.jl
@@ -162,6 +162,7 @@ function make_idx(data, nt::Union{NamedTuple, AbstractDict}, last_val)
 end
 function make_idx(data, pair::Pair, last_val)
     data, ax = make_idx(data, pair.second, last_val)
+    len = recursive_length(data)
     return (data, ViewAxis(last_val:(last_val+len-1), Axis(pair.second)))
 end
 make_idx(data, x, last_val) = (

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -263,7 +263,10 @@ end
     @test ca[Not(2:3)] == getdata(ca)[Not(2:3)]
 
     # Issue #123
-    @test reshape(a, axes(ca)) isa Vector{Float64}
+    # We had to revert this because there is no way to work around
+    # OffsetArrays' type piracy without introducing type piracy
+    # ourselves because `() isa Tuple{N, <:CombinedAxis} where {N}`
+    # @test reshape(a, axes(ca)...) isa Vector{Float64}
 end
 
 @testset "Set" begin
@@ -621,6 +624,10 @@ end
     # Issue #140
     @test ComponentArrays.ArrayInterface.indices_do_not_alias(typeof(ca)) == true
     @test ComponentArrays.ArrayInterface.instances_do_not_alias(typeof(ca)) == false
+
+    # Issue #193
+    # Make sure we aren't doing type piracy on `reshape`
+    @test ndims(dropdims(ones(1,1), dims=(1,2))) == 0
 end
 
 @testset "Autodiff" begin


### PR DESCRIPTION
The method
```julia
Base.reshape(A::AbstractArray, axs::NTuple{N,<:CombinedAxis}) where {N} = reshape(A, _array_axis.(axs))
```
commits type piracy for empty tuples since `() isa NTuple{N, <:CombinedAxis} where {N}`. This was introduced to fight `OffsetArrays`' type piracy for `reshape. We're going to revert this and only make a method for the splatted version. If someone is hitting an issue related to #123, they need to take it up with OffsetArrays