### PR TITLE
Fix extension naming

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ComponentArrays"
 uuid = "b0b7db55-cfe3-40fc-9ded-d10e2dbeff66"
 authors = ["Jonnie Diegelman <47193959+jonniedie@users.noreply.github.com>"]
-version = "0.13.11"
+version = "0.13.12"
 
 [deps]
 ArrayInterface = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"
@@ -34,12 +34,12 @@ StaticArrays = "1"
 julia = "1.6"
 
 [extensions]
-ConstructionBaseExt = "ConstructionBase"
-GPUArraysExt = "GPUArrays"
-RecursiveArrayToolsExt = "RecursiveArrayTools"
-ReverseDiffExt = "ReverseDiff"
-SciMLBaseExt = "SciMLBase"
-StaticArraysExt = "StaticArrays"
+ComponentArraysConstructionBaseExt = "ConstructionBase"
+ComponentArraysGPUArraysExt = "GPUArrays"
+ComponentArraysRecursiveArrayToolsExt = "RecursiveArrayTools"
+ComponentArraysReverseDiffExt = "ReverseDiff"
+ComponentArraysSciMLBaseExt = "SciMLBase"
+ComponentArraysStaticArraysExt = "StaticArrays"
 
 [extras]
 ConstructionBase = "187b0558-2788-49d3-abe0-74a17ed4e7c9"

--- a/ext/ComponentArraysConstructionBaseExt.jl
+++ b/ext/ComponentArraysConstructionBaseExt.jl
@@ -1,4 +1,4 @@
-module ConstructionBaseExt
+module ComponentArraysConstructionBaseExt
 
 using ComponentArrays
 isdefined(Base, :get_extension) ? (using ConstructionBase) : (using ..ConstructionBase)

--- a/ext/ComponentArraysGPUArraysExt.jl
+++ b/ext/ComponentArraysGPUArraysExt.jl
@@ -1,4 +1,4 @@
-module GPUArraysExt
+module ComponentArraysGPUArraysExt
 
 using ComponentArrays, LinearAlgebra
 isdefined(Base, :get_extension) ? (using GPUArrays) : (using ..GPUArrays)

--- a/ext/ComponentArraysRecursiveArrayToolsExt.jl
+++ b/ext/ComponentArraysRecursiveArrayToolsExt.jl
@@ -1,4 +1,4 @@
-module RecursiveArrayToolsExt
+module ComponentArraysRecursiveArrayToolsExt
 
 using ComponentArrays
 isdefined(Base, :get_extension) ? (using RecursiveArrayTools) : (using ..RecursiveArrayTools)

--- a/ext/ComponentArraysReverseDiffExt.jl
+++ b/ext/ComponentArraysReverseDiffExt.jl
@@ -1,4 +1,4 @@
-module ReverseDiffExt
+module ComponentArraysReverseDiffExt
 
 using ComponentArrays
 isdefined(Base, :get_extension) ? (using ReverseDiff) : (using ..ReverseDiff)

--- a/ext/ComponentArraysSciMLBaseExt.jl
+++ b/ext/ComponentArraysSciMLBaseExt.jl
@@ -1,5 +1,5 @@
 # Plotting stuff
-module SciMLBaseExt
+module ComponentArraysSciMLBaseExt
 
 using ComponentArrays
 isdefined(Base, :get_extension) ? (using SciMLBase) : (using ..SciMLBase)

--- a/ext/ComponentArraysStaticArraysExt.jl
+++ b/ext/ComponentArraysStaticArraysExt.jl
@@ -1,4 +1,4 @@
-module StaticArraysExt
+module ComponentArraysStaticArraysExt
 
 using ComponentArrays
 isdefined(Base, :get_extension) ? (using StaticArrays) : (using ..StaticArrays)

--- a/src/ComponentArrays.jl
+++ b/src/ComponentArrays.jl
@@ -54,12 +54,12 @@ include("compat/chainrulescore.jl")
 
 function __init__()
     @static if !isdefined(Base, :get_extension)
-        @require ConstructionBase="187b0558-2788-49d3-abe0-74a17ed4e7c9" include("../ext/ConstructionBaseExt.jl")
-        @require SciMLBase="0bca4576-84f4-4d90-8ffe-ffa030f20462" include("../ext/SciMLBaseExt.jl")
-        @require RecursiveArrayTools="731186ca-8d62-57ce-b412-fbd966d074cd" include("../ext/RecursiveArrayToolsExt.jl")
-        @require StaticArrays="90137ffa-7385-5640-81b9-e52037218182" include("../ext/StaticArraysExt.jl")
-        @require ReverseDiff="37e2e3b7-166d-5795-8a7a-e32c996b4267" include("../ext/ReverseDiffExt.jl")
-        @require GPUArrays="0c68f7d7-f131-5f86-a1c3-88cf8149b2d7" include("../ext/GPUArraysExt.jl")
+        @require ConstructionBase="187b0558-2788-49d3-abe0-74a17ed4e7c9" include("../ext/ComponentArraysConstructionBaseExt.jl")
+        @require SciMLBase="0bca4576-84f4-4d90-8ffe-ffa030f20462" include("../ext/ComponentArraysSciMLBaseExt.jl")
+        @require RecursiveArrayTools="731186ca-8d62-57ce-b412-fbd966d074cd" include("../ext/ComponentArraysRecursiveArrayToolsExt.jl")
+        @require StaticArrays="90137ffa-7385-5640-81b9-e52037218182" include("../ext/ComponentArraysStaticArraysExt.jl")
+        @require ReverseDiff="37e2e3b7-166d-5795-8a7a-e32c996b4267" include("../ext/ComponentArraysReverseDiffExt.jl")
+        @require GPUArrays="0c68f7d7-f131-5f86-a1c3-88cf8149b2d7" include("../ext/ComponentArraysGPUArraysExt.jl")
     end
 end
 


### PR DESCRIPTION
Current naming can cause problems like https://github.com/FluxML/Flux.jl/issues/2242 (note that CA doesn't cause this problem, but it could lead to similar hard-to-debug issues)

Also see discussion in https://github.com/JuliaMath/ChangesOfVariables.jl/pull/13