### PR TITLE
Fix `recursive_eltype` not defined when constructing ComponentArray on the GPU

### DIFF
--- a/ext/ComponentArraysGPUArraysExt.jl
+++ b/ext/ComponentArraysGPUArraysExt.jl
@@ -1,6 +1,7 @@
 module ComponentArraysGPUArraysExt
 
 using ComponentArrays, LinearAlgebra
+using ComponentArrays: recursive_eltype
 isdefined(Base, :get_extension) ? (using GPUArrays) : (using ..GPUArrays)
 
 const GPUComponentArray = ComponentArray{T,N,<:GPUArrays.AbstractGPUArray,Ax} where {T,N,Ax}


### PR DESCRIPTION
Hi,

After the switch to Julia extensions (#192), the methods that are not exported by ComponentArrays are not accessible in the extension source files. This leads to an undefined reference when calling `recursive_eltype` at [line 77](https://github.com/jonniedie/ComponentArrays.jl/blob/97eb9e3db7904ea13b823403d00ddd9e9d6c078f/ext/ComponentArraysGPUArraysExt.jl#L77) in the constructor of ComponentArray on the GPU:

https://github.com/jonniedie/ComponentArrays.jl/blob/97eb9e3db7904ea13b823403d00ddd9e9d6c078f/ext/ComponentArraysGPUArraysExt.jl#L76-L81

This pull request adds the missing import and fixes #209.