### PR TITLE
Make `zero` work correctly for `ComponentVector{Bool}`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ComponentArrays"
 uuid = "b0b7db55-cfe3-40fc-9ded-d10e2dbeff66"
 authors = ["Jonnie Diegelman <47193959+jonniedie@users.noreply.github.com>"]
-version = "0.13.13"
+version = "0.13.14"
 
 [deps]
 ArrayInterface = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"

--- a/src/similar_convert_copy.jl
+++ b/src/similar_convert_copy.jl
@@ -22,7 +22,7 @@ _similar(x::Type, dims) = ComponentArray(similar(x, length.(_array_axis.(dims)))
 _similar(x, T, dims) = ComponentArray(similar(getdata(x), T, length.(_array_axis.(dims))), _component_axis.(dims)...)
 
 
-Base.zero(x::ComponentArray) = zero.(x)
+Base.zero(x::ComponentArray) = ComponentArray(zero(getdata(x)), getaxes(x)...)
 
 ## FIXME: waiting on similar(::Type{<:ComponentArray})
 # Base.zeros(CA::Type{<:ComponentArray}) = (similar(CA) .= 0)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -368,6 +368,10 @@ end
     @test similar(ca, 5) isa typeof(getdata(ca))
     @test similar(ca, Float32, 5) isa typeof(getdata(ca_Float32))
     @test similar(cmat, 5, 5) isa typeof(getdata(cmat))
+
+    # Issue #206
+    x = ComponentArray(a = false, b = true)
+    @test typeof(x) == typeof(zero(x))
 end
 
 @testset "Copy" begin


### PR DESCRIPTION
Fix #206