### PR TITLE
Easily unpack components to static arrays

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,30 @@
 # ComponentArrays.jl NEWS
 Notes on new features (minor releases). For more details on bugfixes and non-feature-adding changes (patch releases), check out the [releases page](https://github.com/jonniedie/ComponentArrays.jl/releases).
 
+### v0.15.0
+- Unpack array components as `StaticArray`s!
+```julia
+julia> x = ComponentArray(a=5, b=[4, 1], c = [1 2; 3 4], d=(e=2, f=[6, 30.0]));
+
+julia> @static_unpack a, b, c, d = x;
+
+julia> a
+5.0
+
+julia> b
+2-element SVector{2, Float64} with indices SOneTo(2):
+ 4.0
+ 1.0
+
+julia> c
+2×2 SMatrix{2, 2, Float64, 4} with indices SOneTo(2)×SOneTo(2):
+ 1.0  2.0
+ 3.0  4.0
+
+julia> d
+ComponentVector{Float64,SubArray...}(e = 2.0, f = [6.0, 30.0])
+```
+
 ### v0.12.0
 - Multiple symbol indexing!
   - Use either an `Array` or `Tuple` of `Symbol`s to extract multiple named components into a new `ComponentArray

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ComponentArrays"
 uuid = "b0b7db55-cfe3-40fc-9ded-d10e2dbeff66"
 authors = ["Jonnie Diegelman <47193959+jonniedie@users.noreply.github.com>"]
-version = "0.14.1"
+version = "0.15.0"
 
 [deps]
 ArrayInterface = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"
@@ -11,6 +11,7 @@ Functors = "d9f16b24-f501-4c13-a1f2-28368ffc5196"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 PackageExtensionCompat = "65ce6f38-6b18-4e1d-a461-8949797d7930"
 StaticArrayInterface = "0d7ed370-da01-4f52-bd93-41d350b8b718"
+StaticArraysCore = "1e83bf80-4336-4d27-bf5d-d5a4f845583c"
 
 [weakdeps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"
@@ -19,7 +20,6 @@ GPUArrays = "0c68f7d7-f131-5f86-a1c3-88cf8149b2d7"
 RecursiveArrayTools = "731186ca-8d62-57ce-b412-fbd966d074cd"
 ReverseDiff = "37e2e3b7-166d-5795-8a7a-e32c996b4267"
 SciMLBase = "0bca4576-84f4-4d90-8ffe-ffa030f20462"
-StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 
 [extensions]
 ComponentArraysAdaptExt = "Adapt"
@@ -28,7 +28,6 @@ ComponentArraysGPUArraysExt = "GPUArrays"
 ComponentArraysRecursiveArrayToolsExt = "RecursiveArrayTools"
 ComponentArraysReverseDiffExt = "ReverseDiff"
 ComponentArraysSciMLBaseExt = "SciMLBase"
-ComponentArraysStaticArraysExt = "StaticArrays"
 
 [compat]
 Adapt = "3"
@@ -43,7 +42,6 @@ RecursiveArrayTools = "2"
 ReverseDiff = "1"
 SciMLBase = "1"
 StaticArrayInterface = "1"
-StaticArrays = "1"
 julia = "1.6"
 
 [extras]
@@ -54,7 +52,6 @@ GPUArrays = "0c68f7d7-f131-5f86-a1c3-88cf8149b2d7"
 RecursiveArrayTools = "731186ca-8d62-57ce-b412-fbd966d074cd"
 ReverseDiff = "37e2e3b7-166d-5795-8a7a-e32c996b4267"
 SciMLBase = "0bca4576-84f4-4d90-8ffe-ffa030f20462"
-StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -9,6 +9,7 @@ makedocs(;
         "Home" => "index.md",
         "Quick Start" => "quickstart.md",
         "Indexing Behavior" => "indexing_behavior.md",
+        "Unpacking to StaticArrays" => "static_unpack.md",
         "Examples" => [
             "examples/DiffEqFlux.md",
             "examples/adaptive_control.md",

--- a/docs/src/static_unpack.md
+++ b/docs/src/static_unpack.md
@@ -1,0 +1,31 @@
+# Unpacking to StaticArrays
+
+Often `ComponentArray`s will hold vector or matrix components for which the user will want to unpack and operate on. If these arrays are small (for example, 3-vectors of positions and velocities), it is usually useful to convert them to `SArray`s from [`StaticArrays.jl`](https://github.com/JuliaArrays/StaticArrays.jl) before doing operations on them to avoid heap allocations. For this reason, we export a `@static_unpack` macro that works similarly to `@unpack` from [`UnPack.jl`](https://github.com/mauro3/UnPack.jl), except it converts all plain arrays to `SArray`s. Anything that isn't a plain array (for example, scalars or inner `ComponentArray`s) will be unpacked as usual.
+
+## Example
+```julia
+julia> x = ComponentVector(a=5, b=[4, 1], c = [1 2; 3 4], d=(e=2, f=[6, 30.0]));
+
+julia> @static_unpack a, b, c, d = x;
+
+julia> a
+5.0
+
+julia> b
+2-element SVector{2, Float64} with indices SOneTo(2):
+ 4.0
+ 1.0
+
+julia> c
+2×2 SMatrix{2, 2, Float64, 4} with indices SOneTo(2)×SOneTo(2):
+ 1.0  2.0
+ 3.0  4.0
+
+julia> d
+ComponentVector{Float64,SubArray...}(e = 2.0, f = [6.0, 30.0])
+```
+
+## Why not just have static ComponentArrays?
+Most of the places `ComponentVector`s are used, the top-level `ComponentVector` is too large to be efficiently backed by a `SVector`. Typically you only need the inner components to be `SVector`s for fast operations (for example, simulating rigid body dynamics where states and derivatives are mostly 3-vectors that need to undergo rotations and translations).
+
+Also, just from experience, immutable `ComponentArray`s tend to be really clunky to work with.

--- a/ext/ComponentArraysStaticArraysExt.jl
+++ b/ext/ComponentArraysStaticArraysExt.jl
@@ -1,8 +1,0 @@
-module ComponentArraysStaticArraysExt
-
-using ComponentArrays, StaticArrays
-
-ComponentArray{A}(::UndefInitializer, ax::Axes) where {A<:StaticArrays.StaticArray,Axes<:Tuple} =
-    ComponentArray(similar(A), ax...)
-
-end

--- a/src/ComponentArrays.jl
+++ b/src/ComponentArrays.jl
@@ -4,6 +4,7 @@ import ChainRulesCore
 import StaticArrayInterface, ArrayInterface, Functors
 
 using LinearAlgebra
+using StaticArraysCore: StaticArray, SArray, SVector, SMatrix
 
 const FlatIdx = Union{Integer, CartesianIndex, CartesianIndices, AbstractArray{<:Integer}}
 const FlatOrColonIdx = Union{FlatIdx, Colon}
@@ -47,6 +48,9 @@ include("plot_utils.jl")
 export labels, label2index
 
 include("compat/chainrulescore.jl")
+
+include("compat/static_arrays.jl")
+export @static_unpack
 
 import PackageExtensionCompat: @require_extensions
 function __init__()

--- a/src/compat/static_arrays.jl
+++ b/src/compat/static_arrays.jl
@@ -2,20 +2,30 @@ function ComponentArray{A}(::UndefInitializer, ax::Axes) where {A<:StaticArray, 
     return ComponentArray(similar(A), ax...)
 end
 
-maybe_SArray(x::SubArray, ::Val{N}, ::FlatAxis) where {N} = SVector{N}(x)
-maybe_SArray(x::Base.ReshapedArray, ::Val, ::ShapedAxis{Sz}) where {Sz} = SArray{Tuple{Sz...}}(x)
-maybe_SArray(x, vals...) = x
+_maybe_SArray(x::SubArray, ::Val{N}, ::FlatAxis) where {N} = SVector{N}(x)
+_maybe_SArray(x::Base.ReshapedArray, ::Val, ::ShapedAxis{Sz}) where {Sz} = SArray{Tuple{Sz...}}(x)
+_maybe_SArray(x, vals...) = x
 
 @generated function static_getproperty(ca::ComponentVector, ::Val{s}) where {s}
     (; idx, ax) = getaxes(ca)[1][s]
-    return :(maybe_SArray(ca.$s, $(Val(length(idx))), $ax))
+    return :(_maybe_SArray(ca.$s, $(Val(length(idx))), $ax))
 end
 
 macro static_unpack(expr)
-    unpacked_var_names = if expr.args[1].head == :tuple
-        expr.args[1].args
+    @assert expr.head == :(=) "Unpack expression must have an equals sign for assignment"
+    lhs, rhs = expr.args
+    unpacked_var_names = if lhs isa Symbol
+        [lhs]
+    elseif lhs.head == :tuple
+        if lhs.args[1] isa Expr
+            lhs.args[1].args
+        else
+            lhs.args
+        end
+    else
+        error("Malformed left side of assignment expression: $(lhs)")
     end
-    parent_var_name = esc(expr.args[end])
+    parent_var_name = esc(rhs)
     out = Expr(:block)
     for name in unpacked_var_names
         esc_name = esc(name)

--- a/src/compat/static_arrays.jl
+++ b/src/compat/static_arrays.jl
@@ -1,0 +1,25 @@
+function ComponentArray{A}(::UndefInitializer, ax::Axes) where {A<:StaticArray, Axes<:Tuple}
+    return ComponentArray(similar(A), ax...)
+end
+
+maybe_SArray(x::SubArray, ::Val{N}, ::FlatAxis) where {N} = SVector{N}(x)
+maybe_SArray(x::Base.ReshapedArray, ::Val, ::ShapedAxis{Sz}) where {Sz} = SArray{Tuple{Sz...}}(x)
+maybe_SArray(x, vals...) = x
+
+@generated function static_getproperty(ca::ComponentVector, ::Val{s}) where {s}
+    (; idx, ax) = getaxes(ca)[1][s]
+    return :(maybe_SArray(ca.$s, $(Val(length(idx))), $ax))
+end
+
+macro static_unpack(expr)
+    unpacked_var_names = if expr.args[1].head == :tuple
+        expr.args[1].args
+    end
+    parent_var_name = esc(expr.args[end])
+    out = Expr(:block)
+    for name in unpacked_var_names
+        esc_name = esc(name)
+        push!(out.args, :($esc_name = static_getproperty($parent_var_name, $(Val(name)))))
+    end
+    return out
+end

--- a/src/compat/static_arrays.jl
+++ b/src/compat/static_arrays.jl
@@ -8,7 +8,7 @@ _maybe_SArray(x, vals...) = x
 
 @generated function static_getproperty(ca::ComponentVector, ::Val{s}) where {s}
     comp_ind = getaxes(ca)[1][s]
-    return :(maybe_SArray(ca.$s, $(Val(length(comp_ind.idx))), $(comp_ind.ax)))
+    return :(_maybe_SArray(ca.$s, $(Val(length(comp_ind.idx))), $(comp_ind.ax)))
 end
 
 macro static_unpack(expr)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -595,6 +595,19 @@ end
     @test ComponentArrays.ArrayInterface.parent_type(cmat) === Matrix{Float64}
 end
 
+@testset "Static Unpack" begin
+    x = ComponentArray(a=5, b=[4, 1], c = [1 2; 3 4], d=(e=2, f=[6, 30.0]))
+    @static_unpack a, b, c, d = x
+    @static_unpack e, f = x.d .+ 0
+
+    @test a isa Float64
+    @test b isa SVector{2, Float64}
+    @test c isa SMatrix{2, 2, Float64, 4}
+    @test d isa ComponentArray
+    @test e isa Float64
+    @test f isa SVector{2, Float64}
+end
+
 @testset "Plot Utilities" begin
     lab = labels(ca2)
     @test lab == [

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -606,6 +606,13 @@ end
     @test d isa ComponentArray
     @test e isa Float64
     @test f isa SVector{2, Float64}
+
+    @static_unpack a = x
+    @static_unpack (; b, c) = x
+
+    @test a isa Float64
+    @test b isa SVector{2, Float64}
+    @test c isa SMatrix{2, 2, Float64, 4}
 end
 
 @testset "Plot Utilities" begin


### PR DESCRIPTION
```julia
julia> using ComponentArrays

julia> ca = ComponentArray(a=5, b=[4, 1], c = [1 2; 3 4], d=(a=2, b=[6, 30.0]))
ComponentVector{Float64}(a = 5.0, b = [4.0, 1.0], c = [1.0 2.0; 3.0 4.0], d = (a = 2.0, b = [6.0, 30.0]))

julia> @static_unpack a, b, c, d = ca
ComponentVector{Float64,SubArray...}(a = 2.0, b = [6.0, 30.0])

julia> a
5.0

julia> b
2-element SVector{2, Float64} with indices SOneTo(2):
 4.0
 1.0

julia> c
2×2 SMatrix{2, 2, Float64, 4} with indices SOneTo(2)×SOneTo(2):
 1.0  2.0
 3.0  4.0

julia> d
ComponentVector{Float64,SubArray...}(a = 2.0, b = [6.0, 30.0])
```