### PR TITLE
Write direct dispatches for `axpy!` & `axpby!`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ComponentArrays"
 uuid = "b0b7db55-cfe3-40fc-9ded-d10e2dbeff66"
 authors = ["Jonnie Diegelman <47193959+jonniedie@users.noreply.github.com>"]
-version = "0.15.3"
+version = "0.15.4"
 
 [deps]
 ArrayInterface = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"

--- a/src/linear_algebra.jl
+++ b/src/linear_algebra.jl
@@ -47,11 +47,13 @@ end
 # Common Accumulation Operations
 ## Needed for CUDA to work properly
 function LinearAlgebra.axpy!(α::Number, x::ComponentArray, y::ComponentArray)
+    getaxes(x) != getaxes(y) && throw(ArgumentError("Axes of `x` and `y` must match"))
     axpy!(α, getdata(x), getdata(y))
     return ComponentArray(y, getaxes(y))
 end
 
 function LinearAlgebra.axpby!(α::Number, x::ComponentArray, β::Number, y::ComponentArray)
+    getaxes(x) != getaxes(y) && throw(ArgumentError("Axes of `x` and `y` must match"))
     axpby!(α, getdata(x), β, getdata(y))
     return ComponentArray(y, getaxes(y))
 end

--- a/src/linear_algebra.jl
+++ b/src/linear_algebra.jl
@@ -43,3 +43,15 @@ for op in [:*, :\, :/]
         end
     end
 end
+
+# Common Accumulation Operations
+## Needed for CUDA to work properly
+function LinearAlgebra.axpy!(α::Number, x::ComponentArray, y::ComponentArray)
+    axpy!(α, getdata(x), getdata(y))
+    return ComponentArray(y, getaxes(y))
+end
+
+function LinearAlgebra.axpby!(α::Number, x::ComponentArray, β::Number, y::ComponentArray)
+    axpby!(α, getdata(x), β, getdata(y))
+    return ComponentArray(y, getaxes(y))
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -123,7 +123,7 @@ end
     # Issue #116
     # Part 2: Arrays of arrays
     @test_throws Exception ComponentVector(a = [[3], [4, 5]], b = 1)
-    
+
     x = ComponentVector(a = [[3, 3], [4, 5]], b = 1)
     @test x.a[1] == [3, 3]
     @test x.b == 1
@@ -666,6 +666,28 @@ end
     # Issue #193
     # Make sure we aren't doing type piracy on `reshape`
     @test ndims(dropdims(ones(1,1), dims=(1,2))) == 0
+end
+
+@testset "axpy! / axpby!" begin
+    y = ComponentArray(a = rand(4), b = rand(4))
+    x = ComponentArray(a = rand(4), b = rand(4))
+    ydata = copy(getdata(y))
+
+    axpy!(2, x, y)
+    @test getdata(y) == 2 .* getdata(x) .+ ydata
+
+    x = ComponentArray(a = rand(4), c = rand(4))
+    @test_throws ArgumentError axpy!(2, x, y)
+
+    y = ComponentArray(a = rand(4), b = rand(4))
+    x = ComponentArray(a = rand(4), b = rand(4))
+    ydata = copy(getdata(y))
+
+    axpby!(2, x, 3, y)
+    @test getdata(y) == 2 .* getdata(x) .+ 3 .* ydata
+
+    x = ComponentArray(a = rand(4), c = rand(4))
+    @test_throws ArgumentError axpby!(2, x, 3, y)
 end
 
 @testset "Autodiff" begin


### PR DESCRIPTION
MWE:

```julia
julia> y = ComponentArray(a = cu(zeros(2)), b = cu(zeros(2)))
ComponentVector{Float32, CuArray{Float32, 1, CUDA.Mem.DeviceBuffer}, Tuple{Axis{(a = 1:2, b = 3:4)}}}(a = Float32[0.0, 0.0], b = Float32[0.0, 0.0])

julia> x = ComponentArray(a = cu(rand(2)), b = cu(rand(2)))
ComponentVector{Float32, CuArray{Float32, 1, CUDA.Mem.DeviceBuffer}, Tuple{Axis{(a = 1:2, b = 3:4)}}}(a = Float32[0.024100939, 0.77158135], b = Float32[0.40818077, 0.44528246])

julia> axpy!(-1, y, x)  # After the patch
ComponentVector{Float32, ComponentVector{Float32, CuArray{Float32, 1, CUDA.Mem.DeviceBuffer}, Tuple{Axis{(a = 1:2, b = 3:4)}}}, Tuple{Axis{(a = 1:2, b = 3:4)}}}(a = Float32[0.024100939, 0.77158135], b = Float32[0.40818077, 0.44528246])

julia> axpy!(-1, y, x)  # Before the patch for CUDA
ERROR: MethodError: no method matching axpy!(::Int64, ::Float32, ::CuPtr{Float32}, ::Int64, ::CuPtr{Float32}, ::Int64)

Closest candidates are:
  axpy!(::Integer, ::Float32, ::Union{Ptr{Float32}, AbstractArray{Float32}}, ::Integer, ::Union{Ptr{Float32}, AbstractArray{Float32}}, ::Integer)
   @ LinearAlgebra ~/.julia/juliaup/julia-1.10.0-beta3+0.x64.linux.gnu/share/julia/stdlib/v1.10/LinearAlgebra/src/blas.jl:509
  axpy!(::Integer, ::ComplexF32, ::Union{Ptr{ComplexF32}, AbstractArray{ComplexF32}}, ::Integer, ::Union{Ptr{ComplexF32}, AbstractArray{ComplexF32}}, ::Integer)
   @ LinearAlgebra ~/.julia/juliaup/julia-1.10.0-beta3+0.x64.linux.gnu/share/julia/stdlib/v1.10/LinearAlgebra/src/blas.jl:509
  axpy!(::Integer, ::ComplexF64, ::Union{Ptr{ComplexF64}, AbstractArray{ComplexF64}}, ::Integer, ::Union{Ptr{ComplexF64}, AbstractArray{ComplexF64}}, ::Integer)
   @ LinearAlgebra ~/.julia/juliaup/julia-1.10.0-beta3+0.x64.linux.gnu/share/julia/stdlib/v1.10/LinearAlgebra/src/blas.jl:509
  ...

Stacktrace:
 [1] axpy!(alpha::Int64, x::ComponentVector{…}, y::ComponentVector{…})
   @ LinearAlgebra.BLAS ~/.julia/juliaup/julia-1.10.0-beta3+0.x64.linux.gnu/share/julia/stdlib/v1.10/LinearAlgebra/src/blas.jl:522
 [2] axpy!(α::Int64, x::ComponentVector{Float32, CuArray{…}, Tuple{…}}, y::ComponentVector{Float32, CuArray{…}, Tuple{…}})
   @ LinearAlgebra ~/.julia/juliaup/julia-1.10.0-beta3+0.x64.linux.gnu/share/julia/stdlib/v1.10/LinearAlgebra/src/generic.jl:1510
 [3] top-level scope
   @ REPL[46]:1
Some type information was truncated. Use `show(err)` to see complete types.
```

I will add tests, but unfortunately without CUDA I couldn't reproduce it since JLArrays would also hit the correct BLAS routines.