### PR TITLE
add missing `LinearAlgebra` methods on GPU

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ComponentArrays"
 uuid = "b0b7db55-cfe3-40fc-9ded-d10e2dbeff66"
 authors = ["Jonnie Diegelman <47193959+jonniedie@users.noreply.github.com>"]
-version = "0.15.3"
+version = "0.15.4"
 
 [deps]
 ArrayInterface = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"

--- a/ext/ComponentArraysGPUArraysExt.jl
+++ b/ext/ComponentArraysGPUArraysExt.jl
@@ -21,6 +21,9 @@ function Base.fill!(A::GPUComponentArray{T}, x) where {T}
 end
 
 LinearAlgebra.dot(x::GPUComponentArray, y::GPUComponentArray) = dot(getdata(x), getdata(y))
+LinearAlgebra.dot(x::GPUComponentArray, y::AbstractGPUArray) = dot(getdata(x), y)
+LinearAlgebra.dot(x::AbstractGPUArray, y::GPUComponentArray) = dot(x, getdata(y))
+
 LinearAlgebra.norm(ca::GPUComponentArray, p::Real) = norm(getdata(ca), p)
 LinearAlgebra.rmul!(ca::GPUComponentArray, b::Number) = GPUArrays.generic_rmul!(ca, b)
 


### PR DESCRIPTION
fix #227 
TODO
- [x] `dot`
- [x] `adoint/transpose` multiplication of vectors simply falls back on to dot (for both real and complex, so those methods aren't necessary).

@jonniedie LMK if you want me to add tests.