### PR TITLE
add method for zygote.seed(::CA)

### DIFF
--- a/ext/ComponentArraysZygoteExt.jl
+++ b/ext/ComponentArraysZygoteExt.jl
@@ -10,4 +10,10 @@ function Zygote.accum(x::ComponentArray, ys::ComponentArray...)
     return ComponentArray(Zygote.accum(getdata(x), getdata.(ys)...), getaxes(x))
 end
 
+function Zygote.seed(x::ComponentArray, ::Val{N}, offset = 0) where{N}
+    data = Zygote.seed(getdata(x), Val(N), offset)
+
+    ComponentArray(data, getaxes(x))
+end
+
 end


### PR DESCRIPTION
fix https://github.com/jonniedie/ComponentArrays.jl/issues/228

with this PR
```julia
julia> Zygote.hessian(x -> sum(x.a .* x.b), p)
4×4 Matrix{Float64}:
 0.0  0.0  1.0  0.0 
 0.0  0.0  0.0  1.0 
 1.0  0.0  0.0  0.0 
 0.0  1.0  0.0  0.0 
```