### PR TITLE
DiffEqFlux Patches

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ComponentArrays"
 uuid = "b0b7db55-cfe3-40fc-9ded-d10e2dbeff66"
 authors = ["Jonnie Diegelman <47193959+jonniedie@users.noreply.github.com>"]
-version = "0.15.4"
+version = "0.15.5"
 
 [deps]
 ArrayInterface = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"

--- a/src/array_interface.jl
+++ b/src/array_interface.jl
@@ -84,7 +84,7 @@ Base.IndexStyle(::Type{<:ComponentArray{T,N,<:A,<:Axes}}) where {T,N,A,Axes} = I
 
 # Since we aren't really using the standard approach to indexing, this will forward things to
 # the correct methods
-Base.to_indices(x::ComponentArray, i::Tuple) = i
+Base.to_indices(x::ComponentArray, i::Tuple{Any}) = i
 Base.to_indices(x::ComponentArray, i::NTuple{N,Union{Integer, CartesianIndex}}) where N = i
 Base.to_indices(x::ComponentArray, i::NTuple{N,Int64}) where N = i
 Base.to_index(x::ComponentArray, i) = i

--- a/src/compat/chainrulescore.jl
+++ b/src/compat/chainrulescore.jl
@@ -18,6 +18,9 @@ end
 
 (p::ChainRulesCore.ProjectTo{ComponentArray})(dx::AbstractArray) = ComponentArray(p.project(dx), p.axes)
 
+# Prevent double projection
+(p::ChainRulesCore.ProjectTo{ComponentArray})(dx::ComponentArray) = dx
+
 function (p::ChainRulesCore.ProjectTo{ComponentArray})(t::ChainRulesCore.Tangent{A, <:NamedTuple}) where {A}
     nt = Functors.fmap(ChainRulesCore.backing, ChainRulesCore.backing(t))
     return ComponentArray(nt)

--- a/src/compat/chainrulescore.jl
+++ b/src/compat/chainrulescore.jl
@@ -1,11 +1,31 @@
 function ChainRulesCore.rrule(::typeof(getproperty), x::ComponentArray, s::Union{Symbol,Val})
-    function getproperty_adjoint(Δ)
-        zero_x = zero(similar(x, eltype(Δ)))
-        setproperty!(zero_x, s, Δ)
-        return (ChainRulesCore.NoTangent(), zero_x, ChainRulesCore.NoTangent())
-    end
+    return getproperty(x, s), Δ -> getproperty_adjoint(Δ, x, s)
+end
 
-    return getproperty(x, s), getproperty_adjoint
+function getproperty_adjoint(Δ, x, s)
+    zero_x = zero(similar(x, eltype(Δ)))
+    zero_x = __setproperty!(zero_x, s, Δ)
+    return (ChainRulesCore.NoTangent(), zero_x, ChainRulesCore.NoTangent())
+end
+
+__setproperty!(x, s, Δ) = __setproperty!(Val(false), x, s, Δ)
+function __setproperty!(::Val{false}, x, s, Δ)
+    setproperty!(x, s, Δ)
+    return x
+end
+# NOTE: I am not sure how this is avoiding the problem of mutation but if we wrap the
+#       mutating function into an `rrule` as done here, Zygote computes the correct
+#       gradient.
+__setproperty!(::Val{true}, x, s::Symbol, Δ) = __setproperty!(Val(true), x, Val(s), Δ)
+function __setproperty!(::Val{true}, x, s::Val, Δ)
+    setproperty!(x, s, Δ)
+    return x
+end
+
+function ChainRulesCore.rrule(cfg::ChainRulesCore.RuleConfig{>:ChainRulesCore.HasReverseMode},
+    ::typeof(__setproperty!), x, s, Δ)
+    y_, pb_f = ChainRulesCore.rrule_via_ad(cfg, __setproperty!, Val(true), x, s, Δ)
+    return y_, pb_f
 end
 
 ChainRulesCore.rrule(::typeof(getdata), x::ComponentArray) = getdata(x), Δ -> (ChainRulesCore.NoTangent(), ComponentArray(Δ, getaxes(x)))

--- a/test/autodiff_tests.jl
+++ b/test/autodiff_tests.jl
@@ -44,6 +44,38 @@ end
     @test gs_ca isa ComponentArray
 end
 
+@testset "Higher Order" begin
+    r = rand(Float32, 1, 128)
+    ps = (; weight = rand(Float32, 1, 1), bias = rand(Float32, 1))
+    ps2 = ComponentArray(ps)
+
+    function loss_function(weight, bias, r)
+        mz, back = Zygote.pullback(r) do r
+            weight * r .+ bias
+        end
+        ep = only(back(ones(size(r))))
+        return sum(mz) + sum(ep)
+    end
+
+    function loss_function(p, r)
+        mz, back = Zygote.pullback(r) do r
+            p.weight * r .+ p.bias
+        end
+        ep = only(back(ones(size(r))))
+        return sum(mz) + sum(ep)
+    end
+
+    loss_function(ps2, r)
+
+    ∂w, ∂b, ∂r = Zygote.jacobian(loss_function, ps.weight, ps.bias, r)
+
+    ∂ps_ca, ∂r_ca = Zygote.jacobian(loss_function, ps2, r)
+
+    @test ∂w[1] ≈ ∂ps_ca[1]
+    @test ∂b[1] ≈ ∂ps_ca[2]
+    @test ∂r ≈ ∂r_ca
+end
+
 
 # # This is commented out because the gradient operation itself is broken due to Zygote's inability
 # # to support mutation and ComponentArray's use of mutation for construction from a NamedTuple.


### PR DESCRIPTION
1. ProjectTo: Protect against Wrapping a ComponentArray into a ComponentArray
2. Higher Order Derivatives while computing Jacobian of FFJORD (Added a non-lux version of https://github.com/LuxDL/Lux.jl/issues/286)