### PR TITLE
Remove unused IdxMap type parameter from ShapedAxis

### DIFF
--- a/src/axis.jl
+++ b/src/axis.jl
@@ -59,14 +59,13 @@ const NullorFlatAxis = Union{NullAxis, FlatAxis}
 
 
 """
-    sa = ShapedAxis(shape, index_map)
+    sa = ShapedAxis(shape)
 
 Preserves higher-dimensional array components in `ComponentArray`s (matrix components, for
 example)
 """
-struct ShapedAxis{Shape, IdxMap} <: AbstractAxis{IdxMap} end
-@inline ShapedAxis(Shape, IdxMap) = ShapedAxis{Shape, IdxMap}()
-ShapedAxis(Shape) = ShapedAxis(Shape, NamedTuple())
+struct ShapedAxis{Shape} <: AbstractAxis{nothing} end
+@inline ShapedAxis(Shape) = ShapedAxis{Shape}()
 ShapedAxis(::Tuple{<:Int}) = FlatAxis()
 
 const Shape = ShapedAxis
@@ -74,7 +73,7 @@ const Shape = ShapedAxis
 unshape(ax) = ax
 unshape(ax::ShapedAxis) = Axis(indexmap(ax))
 
-Base.size(::ShapedAxis{Shape, IdxMap}) where {Shape, IdxMap} = Shape
+Base.size(::ShapedAxis{Shape}) where {Shape} = Shape
 
 
 
@@ -135,7 +134,7 @@ Axis(::NamedTuple{()}) = FlatAxis()
 Axis(x) = FlatAxis()
 
 const NotShapedAxis = Union{Axis{IdxMap}, FlatAxis, NullAxis} where {IdxMap}
-const NotPartitionedAxis = Union{Axis{IdxMap}, FlatAxis, NullAxis, ShapedAxis{Shape, IdxMap}} where {Shape, IdxMap}
+const NotPartitionedAxis = Union{Axis{IdxMap}, FlatAxis, NullAxis, ShapedAxis{Shape}} where {Shape, IdxMap}
 const NotShapedOrPartitionedAxis = Union{Axis{IdxMap}, FlatAxis, NullAxis} where {IdxMap}
 
 

--- a/src/show.jl
+++ b/src/show.jl
@@ -12,14 +12,14 @@ Base.show(io::IO, ::MIME"text/plain", ::PartitionedAxis{PartSz, IdxMap, Ax}) whe
 Base.show(io::IO, ::PartitionedAxis{PartSz, IdxMap, Ax}) where {PartSz, IdxMap, Ax} =
     print(io, "PartitionedAxis($PartSz, $(Ax()))")
 
-Base.show(io::IO, ::ShapedAxis{Shape, IdxMap}) where {Shape, IdxMap} =
-    print(io, "ShapedAxis($Shape, $IdxMap)")
+Base.show(io::IO, ::ShapedAxis{Shape}) where {Shape} =
+    print(io, "ShapedAxis($Shape)")
 
-Base.show(io::IO, ::MIME"text/plain", ::ViewAxis{Inds, IdxMap, Ax}) where {Inds, IdxMap, Ax} = 
+Base.show(io::IO, ::MIME"text/plain", ::ViewAxis{Inds, IdxMap, Ax}) where {Inds, IdxMap, Ax} =
     print(io, "ViewAxis($Inds, $(Ax()))")
-Base.show(io::IO, ::ViewAxis{Inds, IdxMap, <:Ax}) where {Inds, IdxMap, Ax} = 
+Base.show(io::IO, ::ViewAxis{Inds, IdxMap, <:Ax}) where {Inds, IdxMap, Ax} =
     print(io, "ViewAxis($Inds, $(Ax()))")
-Base.show(io::IO, ::ViewAxis{Inds, IdxMap, <:NullorFlatAxis}) where {Inds, IdxMap} = 
+Base.show(io::IO, ::ViewAxis{Inds, IdxMap, <:NullorFlatAxis}) where {Inds, IdxMap} =
     print(io, Inds)
 
 Base.show(io::IO, ci::ComponentIndex) = print(io, "ComponentIndex($(ci.idx), $(ci.ax))")


### PR DESCRIPTION
As I was reviewing the subtypes of `AbstractAxis` to try to get a better understanding of how ComponentArrays work, I couldn't figure out the point of the IdxMap type parameter in ShapedAxis, so I decided to remove it and see what breaks....

But all the tests pass without this type parameter, so maybe we can just remove it? It seems to me that the index mapping is tracked at the level of the axis containing the ShapedAxis. For example, in

```julia
julia> typeof(ComponentArray(a=7, b=rand(2,2)))
ComponentVector{Float64, Vector{Float64}, Tuple{Axis{(a = 1, b = ViewAxis(2:5, ShapedAxis((2, 2), NamedTuple())))}}}
```

the indices of the matrix are tracked by the ViewAxis, not the ShapedAxis.

I changed the supertype from `AbstractAxis{NamedTuple()}` to `AbstractAxis{nothing}` because `nothing` seems like a better indicator of "there's no index information available".

(I also accidentally removed some trailing whitespace, happy to revert that NFC change if desired)