### PR TITLE
fix: loading on 1.12

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ComponentArrays"
 uuid = "b0b7db55-cfe3-40fc-9ded-d10e2dbeff66"
 authors = ["Jonnie Diegelman <47193959+jonniedie@users.noreply.github.com>"]
-version = "0.15.29"
+version = "0.15.30"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/ext/ComponentArraysGPUArraysExt.jl
+++ b/ext/ComponentArraysGPUArraysExt.jl
@@ -83,7 +83,7 @@ for (fname, op) in [(:sum, :(Base.add_sum)), (:prod, :(Base.mul_prod)),
     end
 end
 
-function ComponentArray(nt::NamedTuple{names,
+function ComponentArrays.ComponentArray(nt::NamedTuple{names,
         <:Tuple{Vararg{Union{GPUArrays.AbstractGPUArray, GPUComponentArray}}}}) where {names}
     T = recursive_eltype(nt)
     gpuarray = getdata(first(nt))


### PR DESCRIPTION
Before:

```
┌ ComponentArrays → ComponentArraysGPUArraysExt
│  WARNING: Constructor for type "ComponentArray" was extended in `ComponentArraysGPUArraysExt` without explicit qualification or import.
│    NOTE: Assumed "ComponentArray" refers to `ComponentArrays.ComponentArray`. This behavior is deprecated and may differ in future versions.`
│    NOTE: This behavior may have differed in Julia versions prior to 1.12.
│    Hint: If you intended to create a new generic function of the same name, use `function ComponentArray end`.
│    Hint: To silence the warning, qualify `ComponentArray` as `ComponentArrays.ComponentArray` in the method signature or explicitly `import ComponentArrays: ComponentArray`.
└  
```