### PR TITLE
Fix @static_unpack type parameters and add JET tests

### DIFF
--- a/src/compat/static_arrays.jl
+++ b/src/compat/static_arrays.jl
@@ -3,11 +3,15 @@ function ComponentArray{A}(::UndefInitializer, ax::Axes) where {
     return ComponentArray(similar(A), ax...)
 end
 
-_maybe_SArray(x::SubArray, ::Val{N}, ::FlatAxis) where {N} = SVector{N}(x)
-function _maybe_SArray(x::Base.ReshapedArray, ::Val, ::ShapedAxis{Sz}) where {Sz}
-    SArray{Tuple{Sz...}}(x)
+function _maybe_SArray(x::SubArray{T}, ::Val{N}, ::FlatAxis) where {T, N}
+    SVector{N, T}(Tuple(x))
 end
-_maybe_SArray(x, ::Val, ::Shaped1DAxis{Sz}) where {Sz} = SArray{Tuple{Sz...}}(x)
+function _maybe_SArray(x::Base.ReshapedArray{T, N}, ::Val, ::ShapedAxis{Sz}) where {T, N, Sz}
+    SArray{Tuple{Sz...}, T, N, prod(Sz)}(Tuple(x))
+end
+function _maybe_SArray(x::AbstractArray{T}, ::Val, ::Shaped1DAxis{Sz}) where {T, Sz}
+    SVector{Sz[1], T}(Tuple(x))
+end
 _maybe_SArray(x, vals...) = x
 
 @generated function static_getproperty(ca::ComponentVector, ::Val{s}) where {s}


### PR DESCRIPTION
## Summary

- **Fix `_maybe_SArray` functions in `static_arrays.jl`**: The original code was trying to construct `SVector{N}(x)` and `SArray{Tuple{Sz...}}(x)` without element type parameters and without converting to `Tuple`, which caused `MethodError`s. Now properly constructs `SVector{N, T}(Tuple(x))` and `SArray{Tuple{Sz...}, T, N, prod(Sz)}(Tuple(x))`.
- **Add JET.jl tests**: Added JET.jl as a test dependency and created `test/jet_tests.jl` to test type stability of core ComponentArray operations (getdata, getaxes, getindex).

## Background

Ran JET.jl analysis on the package which identified several issues. The most actionable one was the `_maybe_SArray` functions used by `@static_unpack` which had incorrect type signatures for constructing `SVector` and `SArray` types. The macro now correctly returns `SVector` and `SMatrix` types.

### Before fix:
```julia
julia> @static_unpack a, b = ComponentArray(a = 5.0, b = [1.0, 2.0])
ERROR: MethodError: no method matching (SArray{Tuple{2}})(::SubArray{Float64, 1, Vector{Float64}, Tuple{UnitRange{Int64}}, true})
```

### After fix:
```julia
julia> @static_unpack a, b = ComponentArray(a = 5.0, b = [1.0, 2.0])
julia> typeof(b)
SVector{2, Float64}
```

## Test plan

- [x] All existing tests pass (`Pkg.test()`)
- [x] New JET tests pass
- [x] Manually tested `@static_unpack` with vectors and matrices

cc @ChrisRackauckas

🤖 Generated with [Claude Code](https://claude.com/claude-code)