### PR TITLE
Documentation improvements: fix typo, broken reference, and add missing example

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -17,6 +17,7 @@ makedocs(;
         "Examples" => [
             "examples/DiffEqFlux.md",
             "examples/adaptive_control.md",
+            "examples/coulomb_control.md",
             "examples/ODE_jac.md"
         ],
         "API" => "api.md"

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -9,8 +9,3 @@ language for, but without actually needing a modeling language. The main targets
 in [DifferentialEquations.jl](https://github.com/SciML/DifferentialEquations.jl) and
 [Optim.jl](https://github.com/JuliaNLSolvers/Optim.jl), but anything that requires
 flat vectors is fair game.
-
-```@contents
-Pages = ["examples/example1.md"]
-Depth = 2
-```

--- a/docs/src/indexing_behavior.md
+++ b/docs/src/indexing_behavior.md
@@ -91,7 +91,7 @@ julia> ca[KeepIndex(:b)]
 ComponentVector{Int64}(b = [4, 1])
 ```
 
-Now instead of just returning a plain `Vector`, this returns a `ComponentVector` that keeps the `b` name. Of course, this is still compatible with `view`s, so we could have done `@view ca[KeepIndex(:b)]` if we wanted to retain the view into the origianl.
+Now instead of just returning a plain `Vector`, this returns a `ComponentVector` that keeps the `b` name. Of course, this is still compatible with `view`s, so we could have done `@view ca[KeepIndex(:b)]` if we wanted to retain the view into the original.
 
 Similarly, we can use plain indexes like ranges or integers and they will keep the names of any components they capture:
 


### PR DESCRIPTION
## Summary

This PR fixes several documentation issues:

- **Fixed typo in `indexing_behavior.md:94`**: Changed "origianl" to "original"
- **Removed broken reference in `index.md`**: The `@contents` directive referenced a non-existent file `examples/example1.md`
- **Added missing example to `make.jl`**: The `coulomb_control.md` example exists in `docs/src/examples/` but was not listed in the documentation build configuration

## Changes

1. `docs/src/indexing_behavior.md`: Fixed spelling error
2. `docs/src/index.md`: Removed broken `@contents` directive that referenced non-existent example file
3. `docs/make.jl`: Added `examples/coulomb_control.md` to the pages list so it appears in the built documentation

All changes have been verified by rebuilding the documentation locally with no errors or warnings.

## Test Plan

- [x] Built documentation locally with `julia --project make.jl` - no errors or warnings
- [x] Verified all example files in `docs/src/examples/` are now properly listed in `make.jl`
- [x] Checked that the typo is fixed

cc @ChrisRackauckas

🤖 Generated with [Claude Code](https://claude.com/claude-code)