### PR TITLE
Add friendly_tangent_cache function to Mooncake

### DIFF
--- a/ext/ComponentArraysMooncakeExt.jl
+++ b/ext/ComponentArraysMooncakeExt.jl
@@ -11,4 +11,8 @@ function Mooncake.increment_and_get_rdata!(
     return Mooncake.increment_and_get_rdata!(f.data[:data], r, t)
 end
 
+function Mooncake.friendly_tangent_cache(x::ComponentArray)
+    Mooncake.FriendlyTangentCache{Mooncake.AsPrimal}(copy(x))
+end
+
 end


### PR DESCRIPTION
Register ComponentArray's friendly tangent type. See https://github.com/chalk-lab/Mooncake.jl/issues/1137#issuecomment-4224284241

## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

Add any other context about the problem here.
