### PR TITLE
Mooncake ext: handle ComponentVector cotangents in increment_and_get_rdata!

### DIFF
--- a/ext/ComponentArraysMooncakeExt.jl
+++ b/ext/ComponentArraysMooncakeExt.jl
@@ -11,6 +11,19 @@ function Mooncake.increment_and_get_rdata!(
     return Mooncake.increment_and_get_rdata!(f.data[:data], r, t)
 end
 
+# Same path, but the upstream cotangent has already been wrapped back into a
+# `ComponentVector` (e.g. by a `@from_chainrules`/`@from_rrule` rule whose
+# rrule returned the gradient as a `ComponentVector` instead of the raw
+# backing `Vector`).  Strip the wrapper and accumulate into the underlying
+# data buffer that the FData is tracking.
+function Mooncake.increment_and_get_rdata!(
+        f::Mooncake.FData{@NamedTuple{data::A, axes::Mooncake.NoFData}},
+        r::Mooncake.NoRData,
+        t::ComponentVector{P, A},
+    ) where {P <: Union{Base.IEEEFloat, Complex{<:Base.IEEEFloat}}, A <: Array{P}}
+    return Mooncake.increment_and_get_rdata!(f.data[:data], r, getdata(t))
+end
+
 function Mooncake.friendly_tangent_cache(x::ComponentArray)
     Mooncake.FriendlyTangentCache{Mooncake.AsPrimal}(copy(x))
 end


### PR DESCRIPTION
## Summary

Follow-up to #350. Adds the missing `increment_and_get_rdata!` dispatch for the case where a chain rule (or `@from_chainrules`/`@from_rrule`-generated rule) emits a cotangent for a `ComponentVector` *as a `ComponentVector`* (not as the underlying backing `Vector`).

The existing dispatch only matches `t::Array{<:IEEEFloat}`. When `t` is a `ComponentVector` (which is what SciMLSensitivity's adjoint backpass produces for the parameter cotangent), dispatch falls through to the generic `@from_rrule` path that errors:

```
ArgumentError: The fdata type Mooncake.FData{@NamedTuple{data::Vector{Float32}, axes::Mooncake.NoFData}}, rdata type Mooncake.NoRData, and tangent type ComponentArrays.ComponentVector{...} combination is not supported with @from_chainrules or @from_rrule. This is because Mooncake.jl does not currently have a method of \`increment_and_get_rdata!\` to handle this type combination.
```

This blocks every Lux-based UDE / neural-ODE training loop that uses SciMLSensitivity's `GaussAdjoint(autojacvec=ZygoteVJP)` (or any of the other ChainRules-based adjoints) under `AutoMooncake`. The SciMLSensitivity adjoint backpass returns the parameter gradient as a `ComponentVector`, but the upstream FData is the raw underlying `Vector`, so there's a type mismatch the existing method can't bridge.

## Fix

Add the missing dispatch: when `t` is a `ComponentVector` whose underlying data type matches the FData's payload, strip the wrapper with `getdata(t)` and forward to the existing accumulator.

## Test plan

- [x] End-to-end on the SciMLSensitivity tutorials that were previously blocked:
  - Hybrid pharmacometric ODE with default sensealg — now trains
  - Lux + ComponentArrays neural ODE training with default `GaussAdjoint(ZygoteVJP)` — now trains
  - `second_order_adjoints.md` Adam phase — now trains
  - These tests are part of the SciML/SciMLSensitivity.jl#1419 docs migration; this PR removes the last `!!! note` callouts from several of those tutorials
- [x] Used `OPT.AutoMooncake(; config = Mooncake.Config(; friendly_tangents = true))` in all cases (the path enabled by #350)
- [ ] Happy to add a unit test if you'd like one — let me know what shape

🤖 Generated with [Claude Code](https://claude.com/claude-code)