### PR TITLE
Bump Mooncake compat lower bound to 0.5.25

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ComponentArrays"
 uuid = "b0b7db55-cfe3-40fc-9ded-d10e2dbeff66"
 authors = ["Jonnie Diegelman <47193959+jonniedie@users.noreply.github.com>"]
-version = "0.15.35"
+version = "0.15.36"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"
@@ -47,7 +47,7 @@ GPUArrays = "10.3.1, 11"
 KernelAbstractions = "0.9.29"
 LinearAlgebra = "1.10"
 Optimisers = "0.3, 0.4"
-Mooncake = "0.5"
+Mooncake = "0.5.25"
 Reactant = "0.2.15"
 RecursiveArrayTools = "3.8"
 ReverseDiff = "1.15"


### PR DESCRIPTION
## Summary

v0.15.35 added `Mooncake.friendly_tangent_cache(x::ComponentArray)` to `ext/ComponentArraysMooncakeExt.jl` (commit 29ddd04 — \"Add friendly_tangent_cache function to Mooncake\"), but the Mooncake compat floor was left at `\"0.5\"`. \`Mooncake.friendly_tangent_cache\` / \`Mooncake.FriendlyTangentCache\` were only introduced in **Mooncake 0.5.25** — on 0.5.24 and earlier the extension fails to precompile with:

\`\`\`
ERROR: LoadError: UndefVarError: \`friendly_tangent_cache\` not defined in \`Mooncake\`
Failed to precompile ComponentArraysMooncakeExt
\`\`\`

This has been blocking downstream CI across SciMLSensitivity.jl and other Mooncake consumers whenever the resolver happens to pick a pre-0.5.25 Mooncake — every test job fails at the precompile step before the package under test even loads.

## Change

- \`Mooncake = \"0.5\"\` → \`Mooncake = \"0.5.25\"\` in \`[compat]\`
- \`version = \"0.15.35\"\` → \`version = \"0.15.36\"\` (compat-bump release)

## Verification

\`\`\`
\$ grep -l friendly_tangent_cache ~/.julia/packages/Mooncake/*/src -r | xargs -I{} dirname {} | xargs -I{} grep 'version ' {}/../Project.toml
version = \"0.5.25\"
version = \"0.5.26\"
\`\`\`

(0.5.24 and older Mooncakes in \`~/.julia/packages/Mooncake/\` do not define the symbol.)

## Test plan

- [x] Verified \`friendly_tangent_cache\` / \`FriendlyTangentCache\` exist in Mooncake 0.5.25 and 0.5.26 but not in 0.5.24
- [ ] CI (Mooncake tests should now resolve and precompile cleanly)

Co-Authored-By: Chris Rackauckas <accounts@chrisrackauckas.com>