### PR TITLE
Run runic and update workflow

### DIFF
--- a/.github/workflows/FormatCheck.yml
+++ b/.github/workflows/FormatCheck.yml
@@ -14,6 +14,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+      - uses: julia-actions/setup-julia@v2
+        with:
+          version: '1'
       - uses: fredrikekre/runic-action@v1
         with:
           version: '1'

--- a/ext/ComponentArraysMooncakeExt.jl
+++ b/ext/ComponentArraysMooncakeExt.jl
@@ -54,12 +54,12 @@ function _increment_subarray_fdata!(f_cv, t_data::AbstractArray{P}) where {P <: 
         throw(
             ArgumentError(
                 "ComponentArraysMooncakeExt: cannot aggregate a cotangent of length " *
-                "$(length(t_data)) into a SubArray-backed ComponentVector tangent whose " *
-                "parent has length $(length(parent)). This happens when a cotangent " *
-                "flows into a view that does not fully cover its parent; there is no " *
-                "way to recover the view indices from Mooncake fdata alone. Please " *
-                "file an issue against ComponentArrays.jl with a reproducer so the " *
-                "offending rrule can be patched.",
+                    "$(length(t_data)) into a SubArray-backed ComponentVector tangent whose " *
+                    "parent has length $(length(parent)). This happens when a cotangent " *
+                    "flows into a view that does not fully cover its parent; there is no " *
+                    "way to recover the view indices from Mooncake fdata alone. Please " *
+                    "file an issue against ComponentArrays.jl with a reproducer so the " *
+                    "offending rrule can be patched.",
             ),
         )
     end
@@ -109,7 +109,7 @@ function Mooncake.increment_and_get_rdata!(
 end
 
 function Mooncake.friendly_tangent_cache(x::ComponentArray)
-    Mooncake.FriendlyTangentCache{Mooncake.AsPrimal}(copy(x))
+    return Mooncake.FriendlyTangentCache{Mooncake.AsPrimal}(copy(x))
 end
 
 end


### PR DESCRIPTION
## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API
  
## Additional context

- Run runic for formatting
  Only changes ext/ComponentArraysMooncakeExt.jl
- Add setup-julia to runic workflow
  setup-julia is listed as optional, but not all runners have julia pre-installed. In response to failure in run 60: <https://github.com/SciML/ComponentArrays.jl/actions/runs/24345985853/job/71086853111>
