### PR TITLE
Bump RecursiveArrayTools / SciMLBase compat to include v4 / v3

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ComponentArrays"
 uuid = "b0b7db55-cfe3-40fc-9ded-d10e2dbeff66"
 authors = ["Jonnie Diegelman <47193959+jonniedie@users.noreply.github.com>"]
-version = "0.15.36"
+version = "0.15.37"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"
@@ -49,9 +49,9 @@ LinearAlgebra = "1.10"
 Optimisers = "0.3, 0.4"
 Mooncake = "0.5.25"
 Reactant = "0.2.15"
-RecursiveArrayTools = "3.8"
+RecursiveArrayTools = "3.8, 4"
 ReverseDiff = "1.15"
-SciMLBase = "2"
+SciMLBase = "2, 3"
 StaticArrayInterface = "1"
 StaticArraysCore = "1.4"
 Tracker = "0.2.37"


### PR DESCRIPTION
## Summary

Widen the weak-dep compat so ComponentArrays can load alongside the RAT v4 / SciMLBase v3 stack that ships with OrdinaryDiffEq v7:

- `RecursiveArrayTools: "3.8"` → `"3.8, 4"`
- `SciMLBase: "2"` → `"2, 3"`

Version bump 0.15.36 → 0.15.37.

## Why this is source-level safe

### `ext/ComponentArraysRecursiveArrayToolsExt.jl`

Single method: `Base.Array(VA::AVOA{T, N, <:AbstractVector{<:ComponentVector}})` that only touches `VA.u` / `getaxes(VA.u[1])` / `reduce(hcat, VA.u)`. None of those are affected by the RAT v4 `AbstractVectorOfArray <: AbstractArray` change — that change rebinds **top-level** `sol[i]` / `length(sol)` / `eachindex(sol)` / `iterate(sol)` semantics, but the underlying `.u` field stays a plain `Vector` and behaves identically.

### `ext/ComponentArraysSciMLBaseExt.jl`

Defines `SciMLBase.getsyms(sol::AbstractODESolution{T, N, <:AbstractVector{<:ComponentArray}})` and calls `SciMLBase.has_syms(sol.prob.f)` + `sol.prob.f.syms`. Both `getsyms` and `has_syms` remain present on SciMLBase v3 (verified against `src/symbolic_utils.jl` + `src/scimlfunctions.jl` on master). The `f.syms` field is still on `AbstractSciMLFunction` subtypes — only the `syms` / `paramsyms` / `indepsym` **kwargs** on the SciMLFunction constructors were removed in v3, not the fields themselves.

## Motivation

On SciML/OrdinaryDiffEq.jl#3488 (the v7 release branch), `test (OrdinaryDiffEqDifferentiation_Sparse, 1)` and other downstream jobs hit `Unsatisfiable requirements detected` / `empty intersection` because ComponentArrays' RAT-v4 cap excludes the version the monorepo path-sources. This PR unblocks those.

Part of the broader v7 compat-widening set alongside the previous batch (DiffEqCallbacks#303, DiffEqNoiseProcess#271, DiffEqProblemLibrary#182, JumpProcesses#580, ModelingToolkit#4467, StateSelection#71, ParameterizedFunctions#151, SciMLSensitivity#1431, Sundials#526, ODEInterfaceDiffEq#95, DiffEqFinancial#68, DiffEqPhysics#107, MethodOfLines#552, Catalyst#1463, LSODA#79, MultiScaleArrays#129).

Co-Authored-By: Chris Rackauckas <accounts@chrisrackauckas.com>