### PR TITLE
ext/Mooncake: bridge `copyto!(::ComponentArray, ::Mooncake.Tangent)`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ComponentArrays"
 uuid = "b0b7db55-cfe3-40fc-9ded-d10e2dbeff66"
 authors = ["Jonnie Diegelman <47193959+jonniedie@users.noreply.github.com>"]
-version = "0.15.38"
+version = "0.15.39"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/ext/ComponentArraysMooncakeExt.jl
+++ b/ext/ComponentArraysMooncakeExt.jl
@@ -115,17 +115,57 @@ end
 # === Tangent → ComponentArray gradient copy ===========================================
 # `DifferentiationInterface.value_and_gradient!(::AutoMooncake, …)` writes the gradient
 # into a user-supplied `ComponentArray` buffer with an unconditional
-# `copyto!(grad, new_grad)`. For a flat-Array-backed `ComponentArray` primal,
-# `Mooncake.tangent_type` is `Mooncake.Tangent{@NamedTuple{data::Vector{P}, axes::NoTangent}}`,
-# which is not an `AbstractArray` — so the generic `Base.copyto!(::AbstractArray, ::Any)`
-# fallback tries to iterate the tangent and fails with a `MethodError` for `iterate`.
-# Bridge that by copying the tangent's `data` field directly into the ComponentArray's
-# underlying storage.
+# `copyto!(grad, new_grad)`. Mooncake's `tangent_type` for a `ComponentArray` is a
+# `Mooncake.Tangent` struct, which is not an `AbstractArray` — so the generic
+# `Base.copyto!(::AbstractArray, ::Any)` fallback tries to iterate the tangent and
+# fails with a `MethodError` for `iterate`. Bridge both Tangent shapes that arise.
+
+# (a) Flat-Array-backed CV: tangent_type is
+#     `Tangent{@NamedTuple{data::Vector{P}, axes::NoTangent}}`.
 function Base.copyto!(
         dest::ComponentArray{P, N, <:Array{P}},
         src::Mooncake.Tangent{@NamedTuple{data::A, axes::Mooncake.NoTangent}},
     ) where {P <: _FloatLike, N, A <: Array{P}}
     copyto!(getdata(dest), src.fields.data)
+    return dest
+end
+
+# (b) SubArray-backed CV (from `getproperty(::ComponentVector, ::Symbol)` on a nested
+#     parent): tangent_type nests an inner Tangent that mirrors the SubArray's fields.
+#     Symmetric to the `_increment_subarray_fdata!` path already in this file: copy is
+#     only well-defined when the view fully covers its parent, since the SubArray
+#     indices are not recoverable from Mooncake fdata/tangent shape alone.
+function Base.copyto!(
+        dest::ComponentArray{P, N, <:AbstractArray{P}},
+        src::Mooncake.Tangent{
+            @NamedTuple{
+                data::Mooncake.Tangent{
+                    @NamedTuple{
+                        parent::Array{P, 1},
+                        indices::Mooncake.NoTangent,
+                        offset1::Mooncake.NoTangent,
+                        stride1::Mooncake.NoTangent,
+                    },
+                },
+                axes::Mooncake.NoTangent,
+            },
+        },
+    ) where {P <: _FloatLike, N}
+    parent = src.fields.data.fields.parent
+    if length(parent) != length(getdata(dest))
+        throw(
+            ArgumentError(
+                "ComponentArraysMooncakeExt: cannot copy a SubArray-backed " *
+                    "ComponentVector tangent (parent length $(length(parent))) into a " *
+                    "ComponentArray destination of length $(length(getdata(dest))). This " *
+                    "happens when a tangent flows out of a view that does not fully cover " *
+                    "its parent; there is no way to recover the view indices from Mooncake " *
+                    "tangent fields alone. Please file an issue against ComponentArrays.jl " *
+                    "with a reproducer.",
+            ),
+        )
+    end
+    copyto!(getdata(dest), parent)
     return dest
 end
 

--- a/ext/ComponentArraysMooncakeExt.jl
+++ b/ext/ComponentArraysMooncakeExt.jl
@@ -112,4 +112,21 @@ function Mooncake.friendly_tangent_cache(x::ComponentArray)
     return Mooncake.FriendlyTangentCache{Mooncake.AsPrimal}(copy(x))
 end
 
+# === Tangent → ComponentArray gradient copy ===========================================
+# `DifferentiationInterface.value_and_gradient!(::AutoMooncake, …)` writes the gradient
+# into a user-supplied `ComponentArray` buffer with an unconditional
+# `copyto!(grad, new_grad)`. For a flat-Array-backed `ComponentArray` primal,
+# `Mooncake.tangent_type` is `Mooncake.Tangent{@NamedTuple{data::Vector{P}, axes::NoTangent}}`,
+# which is not an `AbstractArray` — so the generic `Base.copyto!(::AbstractArray, ::Any)`
+# fallback tries to iterate the tangent and fails with a `MethodError` for `iterate`.
+# Bridge that by copying the tangent's `data` field directly into the ComponentArray's
+# underlying storage.
+function Base.copyto!(
+        dest::ComponentArray{P, N, <:Array{P}},
+        src::Mooncake.Tangent{@NamedTuple{data::A, axes::Mooncake.NoTangent}},
+    ) where {P <: _FloatLike, N, A <: Array{P}}
+    copyto!(getdata(dest), src.fields.data)
+    return dest
+end
+
 end

--- a/test/autodiff/autodiff_tests.jl
+++ b/test/autodiff/autodiff_tests.jl
@@ -204,4 +204,22 @@ end
 
     @test Mooncake.friendly_tangent_cache(flat) isa
         Mooncake.FriendlyTangentCache{Mooncake.AsPrimal}
+
+    # `copyto!(::ComponentVector, ::Mooncake.Tangent)` — required so that
+    # `DifferentiationInterface.value_and_gradient!(::AutoMooncake, …)` can write a
+    # Mooncake gradient back into a ComponentArray-shaped `grad` buffer. Without this
+    # bridge the generic AbstractArray `copyto!` fallback tries to iterate the Tangent
+    # and throws a MethodError. See Optimization.jl + AutoMooncake + ComponentArrays
+    # repro that surfaced this.
+    let
+        cv = ComponentArray(a = randn(5), b = randn(3))
+        t = Mooncake.zero_tangent(cv)
+        # Populate the tangent so we can verify copyto! actually transfers the data.
+        copyto!(t.fields.data, 1:8)
+        out = similar(cv)
+        copyto!(out, t)
+        @test getdata(out) == collect(1.0:8.0)
+        @test out.a == [1.0, 2.0, 3.0, 4.0, 5.0]
+        @test out.b == [6.0, 7.0, 8.0]
+    end
 end

--- a/test/autodiff/autodiff_tests.jl
+++ b/test/autodiff/autodiff_tests.jl
@@ -211,15 +211,63 @@ end
     # bridge the generic AbstractArray `copyto!` fallback tries to iterate the Tangent
     # and throws a MethodError. See Optimization.jl + AutoMooncake + ComponentArrays
     # repro that surfaced this.
+
+    # (a) Flat-Array-backed CV: tangent is
+    #     `Tangent{@NamedTuple{data::Vector{P}, axes::NoTangent}}`.
     let
         cv = ComponentArray(a = randn(5), b = randn(3))
         t = Mooncake.zero_tangent(cv)
-        # Populate the tangent so we can verify copyto! actually transfers the data.
         copyto!(t.fields.data, 1:8)
         out = similar(cv)
         copyto!(out, t)
         @test getdata(out) == collect(1.0:8.0)
         @test out.a == [1.0, 2.0, 3.0, 4.0, 5.0]
         @test out.b == [6.0, 7.0, 8.0]
+    end
+
+    # (b) ComponentMatrix (2D underlying storage) — same flat-Array signature, since
+    #     `Matrix{P} <: Array{P}`.
+    let
+        cm = ComponentMatrix(zeros(2, 3), Axis(r = 1:2), Axis(c = 1:3))
+        t = Mooncake.zero_tangent(cm)
+        copyto!(t.fields.data, reshape(1.0:6.0, 2, 3))
+        out = similar(cm)
+        copyto!(out, t)
+        @test getdata(out) == reshape(1.0:6.0, 2, 3)
+    end
+
+    # (c) SubArray-backed CV (from `getproperty` on a nested parent): tangent nests
+    #     a Tangent that mirrors the SubArray's `(parent, indices, offset1, stride1)`
+    #     fields. As with the symmetric `_increment_subarray_fdata!` path, copy is only
+    #     well-defined when the view fully covers its parent (because the SubArray
+    #     indices are not recoverable from Mooncake tangent shape alone).
+    let
+        # Single-top-level-component CV: the inner sub-CV's view spans the entire
+        # parent storage, so the full-cover guard succeeds.
+        parent_cv = ComponentArray(u = ComponentArray(a = randn(3), b = randn(2)))
+        sub_cv = parent_cv.u
+        @assert sub_cv isa ComponentVector{Float64, <:SubArray}
+        t = Mooncake.zero_tangent(sub_cv)
+        copyto!(t.fields.data.fields.parent, 1:5)
+        out = similar(sub_cv)              # flat-Array-backed CV
+        @assert out isa ComponentVector{Float64, <:Array}
+        copyto!(out, t)
+        @test getdata(out) == collect(1.0:5.0)
+        @test out.a == [1.0, 2.0, 3.0]
+        @test out.b == [4.0, 5.0]
+    end
+
+    # (d) Partial-cover SubArray-backed CV: the inner sub-CV views only part of the
+    #     parent storage. The full-cover guard fires with a clear ArgumentError rather
+    #     than a confusing MethodError or silently producing wrong gradients.
+    let
+        parent_cv = ComponentArray(
+            u = ComponentArray(a = randn(3), b = randn(2)), v = randn(5),
+        )
+        sub_cv = parent_cv.u
+        @assert sub_cv isa ComponentVector{Float64, <:SubArray}
+        t = Mooncake.zero_tangent(sub_cv)
+        out = similar(sub_cv)
+        @test_throws ArgumentError copyto!(out, t)
     end
 end


### PR DESCRIPTION
> Please ignore until reviewed by @ChrisRackauckas.

## Summary

Bridge `copyto!(::ComponentArray, ::Mooncake.Tangent)` for both the flat-Array-backed and SubArray-backed `ComponentVector` tangent shapes so Mooncake gradients can be written back into a `ComponentArray`-shaped buffer.

## The bug

```julia
using Optimization, OptimizationOptimJL, ComponentArrays
import Mooncake

f(x, _) = sum(abs2, x)
optf = OptimizationFunction(f, AutoMooncake())

# works
solve(OptimizationProblem(optf, randn(100)), LBFGS(); maxiters=10)

# fails:
#   MethodError: no method matching iterate(
#     ::Mooncake.Tangent{@NamedTuple{data::Vector{Float64}, axes::Mooncake.NoTangent}})
solve(OptimizationProblem(optf, ComponentArray(a=randn(100))), LBFGS(); maxiters=10)
```

## Root cause

`DifferentiationInterface.value_and_gradient!(::AutoMooncake, …)` writes the gradient into the user-supplied `grad` buffer with an unconditional `copyto!(grad, new_grad)` (DI's `DifferentiationInterfaceMooncakeExt/onearg.jl:153`). For a plain `Vector{Float64}` primal this works because `Mooncake.tangent_type(Vector{Float64}) === Vector{Float64}`, so the source is an array. For a `ComponentArray` primal, however, `Mooncake.tangent_type` is a `Mooncake.Tangent` struct — not an `AbstractArray` — so the generic `Base.copyto!(::AbstractArray, ::Any)` fallback drops into the iterate-based path at `abstractarray.jl:934` and throws `MethodError` for `iterate`.

DI's twoarg and forward call sites already handle the "tangent ≠ primal-shape" case via `dy isa tangent_type(Y) ? dy : _copy_to_output!!(prep.dy_righttype, dy)`. The `value_and_gradient!` path is the one missed case; a parallel issue could be filed against DI to apply the same pattern there. Until that lands, defining `copyto!` for the (`ComponentArray`, `Mooncake.Tangent`) pairs fully unblocks the user-visible failure in Optimization.jl + AutoMooncake + ComponentArrays.

## Coverage

I probed the obvious variations against this branch. Results:

| # | Case | Status |
|---|---|---|
| 1 | Flat 1D `ComponentVector` | ✅ original failing case — fixed by overload (a) |
| 2 | Nested CV (`ComponentArray(u=…, p=ComponentArray(…))`) | ✅ still flat-backed underneath; same overload (a) |
| 3 | `ComponentMatrix` (2D backing) | ✅ `Matrix{P} <: Array{P}` — overload (a) covers it; regression test added |
| 4 | `Float32` CV | ✅ `_FloatLike` covers it |
| 5 | SubArray-backed CV, full cover | ✅ new overload (b); test added |
| 6 | SubArray-backed CV, partial cover | ✅ clear `ArgumentError` (symmetric to existing `_increment_subarray_fdata!` guard); test added |
| 7 | Non-mutating `DI.gradient(f, prep, ::AutoMooncake, ::CV)` | ⚠️ returns a `Mooncake.Tangent`, not a CV — outside CA's reach, needs DI/Mooncake-level fix |
| 8 | `OptimizationProblem(optf, parent_cv.u)` where `u` is a flat 1D component | ⚠️ `parent_cv.u` returns a raw `SubArray`, not a CV — Mooncake-on-SubArrays issue, outside CA's scope |

(7) is a latent DI contract issue: the non-mutating `DI.gradient` path runs `_copy_output(new_grad)` and returns the deep-copied Tangent, so the caller gets back a type that doesn't match the input's shape. The right fix is in DI (mirror the `_copy_to_output!!` pattern) or Mooncake's `_copy_output` dispatch. Mentioning here for visibility but deliberately not addressing in this PR.

(8) requires a Mooncake-side `copyto!(::Vector, ::Mooncake.Tangent{…SubArray-tangent…})` since the destination isn't a `ComponentArray` at all once the wrapper is dropped.

## What this PR does

- `ext/ComponentArraysMooncakeExt.jl`: adds two `Base.copyto!` overloads —
  - (a) `(ComponentArray{P,N,<:Array{P}}, Tangent{@NamedTuple{data::Array{P}, axes::NoTangent}})` → copies `src.fields.data` into `getdata(dest)`.
  - (b) `(ComponentArray{P,N,<:AbstractArray{P}}, Tangent{@NamedTuple{data::Tangent{@NamedTuple{parent::Vector{P}, indices::NoTangent, offset1::NoTangent, stride1::NoTangent}}, axes::NoTangent}})` → copies `src.fields.data.fields.parent` into `getdata(dest)`, guarded by a `length(parent) == length(getdata(dest))` full-cover check that throws a clear `ArgumentError` on partial-cover views (symmetric to the existing `_increment_subarray_fdata!` block).
- `test/autodiff/autodiff_tests.jl`: adds four targeted tests in the `Mooncake` testset — flat CV, `ComponentMatrix`, full-cover SubArray-backed CV, and `@test_throws ArgumentError` for partial-cover SubArray-backed CV.
- `Project.toml`: bumps `version = "0.15.39"`.

## Local verification

`Autodiff` test group passes with `Mooncake` testset at 15/15 (was 7/7 on `main`).

End-to-end with the dev'd `ComponentArrays`:

```
---- ComponentArray case ----
retcode = Success   objective = 0.0
typeof(sol.u) = ComponentVector{Float64, Vector{Float64}, …}
OK
```

Previous CI on the (a)-only commit was 18/18 green (all matrix entries for Julia 1, lts, pre × Core/Autodiff/Downstream/Reactant/GPU/nopre, plus Runic, build, doc-build).

## Test plan

- [ ] CI: `Core` group passes
- [ ] CI: `Autodiff` group passes (new `copyto!(::CV, ::Mooncake.Tangent)` cases in `test/autodiff/autodiff_tests.jl`)
- [ ] CI: `Downstream` group passes
- [ ] CI: `Reactant` group passes
- [ ] CI: `nopre` group passes
