### PR TITLE
Update Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,5 @@
 # https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
 version: 2
-enable-beta-ecosystems: true # Julia ecosystem
 updates:
   - package-ecosystem: "github-actions"
     directory: "/" # Location of package manifests
@@ -17,6 +16,3 @@ updates:
       all-julia-packages:
         patterns:
           - "*"
-    ignore:
-      - dependency-name: "crate-ci/typos"
-        update-types: ["version-update:semver-patch", "version-update:semver-minor"]


### PR DESCRIPTION
Removed `enable-beta-ecosystems` since Julia is no longer a beta ecosystem and the option is not currently in use per the docs (https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#enable-beta-ecosystems-), and dropped the `crate-ci/typos` ignore as it is not used anywhere in this repo.

closes #371