### PR TITLE
CI: add SpellCheck workflow and clean up Dependabot config (#371)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,11 +1,13 @@
 # https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
 version: 2
-enable-beta-ecosystems: true # Julia ecosystem
 updates:
   - package-ecosystem: "github-actions"
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
+    ignore:
+      - dependency-name: "crate-ci/typos"
+        update-types: ["version-update:semver-patch", "version-update:semver-minor"]
   - package-ecosystem: "julia"
     directories:
       - "/"
@@ -17,6 +19,3 @@ updates:
       all-julia-packages:
         patterns:
           - "*"
-    ignore:
-      - dependency-name: "crate-ci/typos"
-        update-types: ["version-update:semver-patch", "version-update:semver-minor"]

--- a/.github/workflows/SpellCheck.yml
+++ b/.github/workflows/SpellCheck.yml
@@ -1,0 +1,13 @@
+name: Spell Check
+
+on: [pull_request]
+
+jobs:
+  typos-check:
+    name: Spell Check with Typos
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Actions Repository
+        uses: actions/checkout@v6
+      - name: Check spelling
+        uses: crate-ci/typos@v1.34.0

--- a/.typos.toml
+++ b/.typos.toml
@@ -1,0 +1,3 @@
+[default.extend-words]
+# `temp_noth` test variable (component array holding a `nothing` field)
+noth = "noth"


### PR DESCRIPTION
> [!NOTE]
> Please ignore until reviewed by @ChrisRackauckas. Opened as a draft.

Closes #371, and brings the CI in line with the SciML standard (using Sundials.jl as the reference).

## What this changes

**`.github/dependabot.yml`**
- Removed `enable-beta-ecosystems: true`. The [current Dependabot options reference](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference) lists this key as *"Not currently in use"* — the Julia ecosystem no longer requires it, so it's dead config (issue point 1).
- Moved the `crate-ci/typos` `ignore` rule out of the `julia` ecosystem and into the `github-actions` ecosystem. `crate-ci/typos` is a GitHub Action, not a Julia package, so the ignore had no effect where it was (issue point 2). It belongs alongside the action so the version pinned in the new SpellCheck workflow isn't bumped by patch/minor PRs — this matches Sundials.jl's `dependabot.yml`.

**`.github/workflows/SpellCheck.yml`** (new)
- Standard SciML spell-check workflow running `crate-ci/typos` on PRs, matching `Sundials.jl/.github/workflows/SpellCheck.yml`. This is the thing @ChrisRackauckas asked to "enable here too" in the issue thread. Pinned to `v1.34.0`.

**`.typos.toml`** (new)
- `typos` flags the `temp_noth` test variable in `test/core_tests.jl` (it wants `north`). Added a single `[default.extend-words]` exception for `noth` rather than renaming a test variable. This is the only false positive in the repo.

## Verification

Ran `crate-ci/typos` v1.34.0 locally against the repo (same version the workflow pins):
- Before the config: 3 errors (all the `temp_noth` occurrences).
- After adding `.typos.toml`: exit 0, clean.

Both YAML files validated with `yaml.safe_load`.

## Not included here (possible follow-up)

Sundials.jl's `Tests.yml`/`Downgrade.yml` use the reusable `SciML/.github/.github/workflows/tests.yml@v1` workflow. ComponentArrays.jl still uses a self-contained `ci.yml` with a group matrix (Core/Autodiff/GPU/Downstream/Reactant/nopre). Converting to the reusable workflow is the larger remaining "match Sundials" step, but the reusable workflow uses `codecov-action` with `fail_ci_if_error: true` + a `CODECOV_TOKEN` secret, which I can't verify is configured for this repo without risking red CI. Happy to do that conversion as a separate PR if wanted.

Co-Authored-By: Chris Rackauckas <accounts@chrisrackauckas.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)