### PR TITLE
Migrate CI to centralized SciML reusable workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,9 +5,6 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
-    ignore:
-      - dependency-name: "crate-ci/typos"
-        update-types: ["version-update:semver-patch", "version-update:semver-minor"]
   - package-ecosystem: "julia"
     directories:
       - "/"

--- a/.github/workflows/FormatCheck.yml
+++ b/.github/workflows/FormatCheck.yml
@@ -1,5 +1,4 @@
-name: format-check
-
+name: Format Check
 on:
   push:
     branches:
@@ -8,15 +7,11 @@ on:
       - 'release-'
     tags: '*'
   pull_request:
-
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 jobs:
   runic:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-      - uses: julia-actions/setup-julia@v3
-        with:
-          version: '1'
-      - uses: fredrikekre/runic-action@v1
-        with:
-          version: '1'
+    name: Format Check
+    uses: "SciML/.github/.github/workflows/runic.yml@v1"
+    secrets: "inherit"

--- a/.github/workflows/SpellCheck.yml
+++ b/.github/workflows/SpellCheck.yml
@@ -1,13 +1,10 @@
 name: Spell Check
-
 on: [pull_request]
-
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 jobs:
   typos-check:
     name: Spell Check with Typos
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout Actions Repository
-        uses: actions/checkout@v6
-      - name: Check spelling
-        uses: crate-ci/typos@v1.34.0
+    uses: "SciML/.github/.github/workflows/spellcheck.yml@v1"
+    secrets: "inherit"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,10 +7,12 @@ on:
     branches:
       - main
     tags: '*'
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 jobs:
   test:
-    name: Julia ${{ matrix.version }} - ${{ matrix.group }} - ${{ github.event_name }}
-    runs-on: ${{ matrix.os }}
+    name: Tests
     strategy:
       fail-fast: false
       matrix:
@@ -23,12 +25,8 @@ jobs:
           - nopre
         version:
           - 'lts'
-          - '1' # Leave this line unchanged. '1' will automatically expand to the latest stable 1.x release of Julia.
+          - '1'
           - 'pre'
-        os:
-          - ubuntu-latest
-        arch:
-          - x64
         exclude:
           - group: nopre
             version: 'pre'
@@ -36,27 +34,8 @@ jobs:
             version: 'pre'
           - group: Reactant
             version: 'pre'
-    steps:
-      - uses: actions/checkout@v6
-      - uses: julia-actions/setup-julia@v3
-        with:
-          version: ${{ matrix.version }}
-          arch: ${{ matrix.arch }}
-      - uses: actions/cache@v5
-        env:
-          cache-name: cache-artifacts
-        with:
-          path: ~/.julia/artifacts
-          key: ${{ runner.os }}-test-${{ env.cache-name }}-${{ hashFiles('**/Project.toml') }}
-          restore-keys: |
-            ${{ runner.os }}-test-${{ env.cache-name }}-
-            ${{ runner.os }}-test-
-            ${{ runner.os }}-
-      - uses: julia-actions/julia-buildpkg@v1
-      - uses: julia-actions/julia-runtest@v1
-        env:
-          GROUP: ${{ matrix.group }}
-      - uses: julia-actions/julia-processcoverage@v1
-      - uses: codecov/codecov-action@v6
-        with:
-          file: lcov.info
+    uses: "SciML/.github/.github/workflows/tests.yml@v1"
+    with:
+      group: "${{ matrix.group }}"
+      julia-version: "${{ matrix.version }}"
+    secrets: "inherit"

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,23 +1,16 @@
 name: Documentation
-
 on:
   push:
     branches: [main]
     tags: '*'
   pull_request:
-
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 jobs:
-  build:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-      - uses: julia-actions/setup-julia@latest
-        with:
-          version: '1.10'
-      - name: Install dependencies
-        run: julia --project=docs/ -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate()'
-      - name: Build and deploy
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # For authentication with GitHub Actions token
-          DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }} # For authentication with SSH deploy key
-        run: julia --project=docs/ docs/make.jl
+  docs:
+    name: Documentation
+    uses: "SciML/.github/.github/workflows/documentation.yml@v1"
+    with:
+      coverage: false
+    secrets: "inherit"

--- a/.github/workflows/downgrade.yml
+++ b/.github/workflows/downgrade.yml
@@ -10,27 +10,21 @@ on:
       - main
     paths-ignore:
       - 'docs/**'
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 jobs:
-  test:
-    runs-on: ubuntu-latest
+  downgrade:
+    name: Downgrade
     strategy:
+      fail-fast: false
       matrix:
         group:
           - Core
-        downgrade_mode: ['alldeps']
-        julia-version: ['1.10']
-    steps:
-      - uses: actions/checkout@v6
-      - uses: julia-actions/setup-julia@v3
-        with:
-          version: ${{ matrix.julia-version }}
-      - uses: julia-actions/julia-downgrade-compat@v2
-#        if: ${{ matrix.version == '1.6' }}
-        with:
-          skip: Pkg,TOML
-      - uses: julia-actions/julia-buildpkg@v1
-      - uses: julia-actions/julia-runtest@v1
-        with:
-          allow_reresolve: false
-        env:
-          GROUP: ${{ matrix.group }}
+    uses: "SciML/.github/.github/workflows/downgrade.yml@v1"
+    with:
+      group: "${{ matrix.group }}"
+      julia-version: "1.10"
+      skip: "Pkg,TOML"
+      allow-reresolve: false
+    secrets: "inherit"


### PR DESCRIPTION
Please ignore until reviewed by @ChrisRackauckas

Normalizes this repo's CI to the standard SciML reusable-workflow set, with every caller pinned at `@v1` and `secrets: inherit`.

## Workflows converted
- **`ci.yml` (Tests)** → calls `SciML/.github/.github/workflows/tests.yml@v1`. The full `version × group` matrix is reproduced exactly: groups `Core, Autodiff, GPU, Downstream, Reactant, nopre`; versions `lts, 1, pre`; with the same three excludes (`nopre/pre`, `Downstream/pre`, `Reactant/pre`). Coverage was collected in the original (codecov), so it stays on (reusable default). The original `os: ubuntu-latest` / `arch: x64` were the reusable-workflow defaults, so they are inherited rather than restated.
- **`docs.yml` (Documentation)** → calls `documentation.yml@v1`. Original docs build did not collect coverage, so `coverage: false`.
- **`FormatCheck.yml` (Runic)** → calls `runic.yml@v1`. The repo already ran `fredrikekre/runic-action`, so this is a pure centralization; no source reformatting was required (verified locally with Runic v1.7.0, `--check` exit 0).
- **`SpellCheck.yml` (typos)** → calls `spellcheck.yml@v1`.
- **`downgrade.yml` (Downgrade)** → calls `downgrade.yml@v1`, preserving group `Core`, `julia-version: 1.10`, `skip: Pkg,TOML`, and `allow-reresolve: false`. The original `paths-ignore: docs/**` triggers are preserved.

## Added
None — all five standard checks (Tests, Documentation, Runic, SpellCheck, Downgrade) already existed and were only centralized.

## Not added (correctly absent)
No downstream/IntegrationTest, benchmark, or QA workflow existed, so none were invented. (Note: `ci.yml` has an in-repo `Downstream` *test group* driven by `GROUP`, which is preserved as a matrix group — it is not a separate downstream.yml workflow.)

## dependabot.yml
- Removed the per-dependency `crate-ci/typos` ignore block (standing policy: keep everything current).
- `github-actions` block (`/`, weekly) and `julia` block (`/`, `/docs`, `/test`, daily, `all-julia-packages` group) preserved as-is.

## CompatHelper
No `CompatHelper.yml` existed; nothing to remove.

## TagBot
Left unchanged.

## Typos findings
Ran `typos` (CLI 1.34.0) locally over the tree: clean, exit 0. The repo's `.typos.toml` (extend-word `noth`) covers the one known false positive. The centralized check uses typos 1.47.0 (newer than the previous 1.34.0 pin), which could surface additional findings; none are anticipated, but a newer typos version may flag items the older pin did not.

## Heads-up for branch protection
Check names change with centralization (e.g. the test job name becomes `Tests` from the reusable workflow rather than `Julia <ver> - <group> - <event>`). **Branch-protection required-status-checks must be updated** to the new check names or required checks will appear missing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)