### PR TITLE
Canonical CI: grouped-tests.yml + root test/test_groups.toml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,31 +11,6 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 jobs:
-  test:
-    name: Tests
-    strategy:
-      fail-fast: false
-      matrix:
-        group:
-          - Core
-          - Autodiff
-          - GPU
-          - Downstream
-          - Reactant
-          - nopre
-        version:
-          - 'lts'
-          - '1'
-          - 'pre'
-        exclude:
-          - group: nopre
-            version: 'pre'
-          - group: Downstream
-            version: 'pre'
-          - group: Reactant
-            version: 'pre'
-    uses: "SciML/.github/.github/workflows/tests.yml@v1"
-    with:
-      group: "${{ matrix.group }}"
-      julia-version: "${{ matrix.version }}"
+  tests:
+    uses: "SciML/.github/.github/workflows/grouped-tests.yml@v1"
     secrets: "inherit"

--- a/test/test_groups.toml
+++ b/test/test_groups.toml
@@ -1,0 +1,17 @@
+[Core]
+versions = ["lts", "1", "pre"]
+
+[Autodiff]
+versions = ["lts", "1", "pre"]
+
+[GPU]
+versions = ["lts", "1", "pre"]
+
+[Downstream]
+versions = ["lts", "1"]
+
+[Reactant]
+versions = ["lts", "1"]
+
+[nopre]
+versions = ["lts", "1"]


### PR DESCRIPTION
Converts the root CI workflow (`.github/workflows/ci.yml`) to the canonical thin caller of `SciML/.github` `grouped-tests.yml@v1`, with the package's own group × version test matrix declared once in a root `test/test_groups.toml` instead of being hand-maintained in YAML.

## What changed

- **`.github/workflows/ci.yml`**: the inlined `group × version` matrix `test` job (which already called `tests.yml@v1`) is replaced by a thin caller:
  ```yaml
  jobs:
    tests:
      uses: "SciML/.github/.github/workflows/grouped-tests.yml@v1"
      secrets: "inherit"
  ```
  `name: CI`, the `on:` triggers, and the `concurrency:` block are preserved verbatim, so the `Tests` branch-protection status checks are unaffected.
- **`test/test_groups.toml`** (new): declares the matrix.

No `with:` overrides are needed: `test/runtests.jl` already dispatches on the standard `GROUP` env var (default), check-bounds/coverage/coverage-directories/apt-packages all match the workflow defaults, and this is a Linux-only suite so no `os` axis is added (defaults to `ubuntu-latest`).

## Matrix match

The old workflow matrix was `group: [Core, Autodiff, GPU, Downstream, Reactant, nopre] × version: [lts, 1, pre]` with `pre` excluded for `nopre`, `Downstream`, and `Reactant` (15 cells). Running `compute_affected_sublibraries.jl . --root-matrix` against the new `test/test_groups.toml` reproduces this exactly: **15/15 (group, version) cells match** (verified by set equality; no missing, no extra). TOML and YAML both parse cleanly.

## QA

Category A: `runtests.jl` already has full `GROUP` dispatch including the QA-equivalent `nopre` group (JET + Aqua), so no `runtests.jl` change and no local Aqua/JET run was required — static matrix verification only. No source bugs surfaced. No tests were skipped, broadened, or silenced.

Ignore until reviewed by @ChrisRackauckas.