### PR TITLE
Make lu/qr of ComponentMatrix preserve the wrapper on factors

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ComponentArrays"
 uuid = "b0b7db55-cfe3-40fc-9ded-d10e2dbeff66"
 authors = ["Jonnie Diegelman <47193959+jonniedie@users.noreply.github.com>"]
-version = "0.15.41"
+version = "0.15.42"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/src/ComponentArrays.jl
+++ b/src/ComponentArrays.jl
@@ -5,8 +5,8 @@ import StaticArrayInterface, ArrayInterface, Functors
 import ConstructionBase
 import Adapt
 
-using LinearAlgebra: LinearAlgebra, Adjoint, Cholesky, Diagonal, I, LU, Transpose,
-    UniformScaling, axpby!, axpy!, ldiv!
+using LinearAlgebra: LinearAlgebra, Adjoint, Cholesky, ColumnNorm, Diagonal, I, LU,
+    NoPivot, RowMaximum, RowNonZero, Transpose, UniformScaling, axpby!, axpy!, ldiv!
 using StaticArraysCore: StaticArray, SArray, SVector
 
 const FlatIdx = Union{Integer, CartesianIndex, CartesianIndices, AbstractArray{<:Integer}}

--- a/src/linear_algebra.jl
+++ b/src/linear_algebra.jl
@@ -8,6 +8,40 @@ function ArrayInterface.lu_instance(x::ComponentMatrix)
     return LU{luT}(similar(x), ipiv, info)
 end
 
+# The generic `lu`/`qr` copy through `similar(A, T, dims)`, which drops the axes
+# and returns a plain `Matrix`, whereas the in-place `lu!`/`qr!` (ComponentMatrix
+# is strided, so they hit LAPACK directly) keep the ComponentMatrix wrapper on the
+# factors. Make the out-of-place versions and the `ArrayInterface` instance
+# functions preserve the wrapper too, so callers that type a cache from the
+# instance functions and later store either variant (e.g. LinearSolve) don't hit
+# a cache type mismatch.
+function LinearAlgebra.lu(
+        A::ComponentMatrix, pivot::Union{NoPivot, RowNonZero, RowMaximum} = RowMaximum();
+        kwargs...,
+    )
+    F = LinearAlgebra.lu(getdata(A), pivot; kwargs...)
+    return LU(ComponentArray(F.factors, getaxes(A)), F.ipiv, F.info)
+end
+
+function LinearAlgebra.qr(
+        A::ComponentMatrix, pivot::Union{NoPivot, ColumnNorm} = NoPivot();
+        kwargs...,
+    )
+    F = LinearAlgebra.qr(getdata(A), pivot; kwargs...)
+    return _rewrap_qr(F, getaxes(A))
+end
+
+function ArrayInterface.qr_instance(A::ComponentMatrix, pivot = NoPivot())
+    F = ArrayInterface.qr_instance(getdata(A), pivot)
+    return _rewrap_qr(F, getaxes(A))
+end
+
+function _rewrap_qr(F::LinearAlgebra.QRCompactWY, ax)
+    return LinearAlgebra.QRCompactWY(ComponentArray(F.factors, ax), F.T)
+end
+_rewrap_qr(F::LinearAlgebra.QRPivoted, ax) = LinearAlgebra.QRPivoted(ComponentArray(F.factors, ax), F.τ, F.jpvt)
+_rewrap_qr(F, ax) = F
+
 # Helpers for dealing with adjoints and such
 _first_axis(x::AbstractComponentVecOrMat) = getaxes(x)[1]
 

--- a/test/math_tests.jl
+++ b/test/math_tests.jl
@@ -143,4 +143,25 @@ s2_D = out2 * in2'
     (FlatAxis(), Axis(u2 = 1))
 
 @test ComponentArrays.ArrayInterface.lu_instance(cmat).factors isa ComponentMatrix
+
+# `lu`, `lu!`, and `lu_instance` (same for qr) must all keep the ComponentMatrix
+# wrapper on the factors, or caches typed from the instance functions break when
+# a `lu`/`qr` result is stored in them (LinearSolve's default solver does this;
+# see the PR #390 downstream CI failure).
+let A = cmat + I
+    F = lu(A)
+    @test F.factors isa ComponentMatrix
+    @test typeof(F) === typeof(ComponentArrays.ArrayInterface.lu_instance(A))
+    @test typeof(F) === typeof(lu!(copy(A)))
+    @test getdata(F.factors) == lu(getdata(A)).factors
+    @test F \ getdata(ca) ≈ getdata(A) \ getdata(ca)
+
+    Fqr = qr(A)
+    @test Fqr.factors isa ComponentMatrix
+    @test typeof(Fqr) === typeof(ComponentArrays.ArrayInterface.qr_instance(A, NoPivot()))
+    @test typeof(Fqr) === typeof(qr!(copy(A)))
+    @test Fqr \ getdata(ca) ≈ getdata(A) \ getdata(ca)
+    @test typeof(qr(A, ColumnNorm())) === typeof(qr!(copy(A), ColumnNorm())) ===
+        typeof(ComponentArrays.ArrayInterface.qr_instance(A, ColumnNorm()))
+end
 @test ComponentArrays.ArrayInterface.parent_type(cmat) === Matrix{Float64}


### PR DESCRIPTION
> [!NOTE]
> Please ignore this PR until it has been reviewed by @ChrisRackauckas.

Fixes the Downstream CI failure seen in https://github.com/SciML/ComponentArrays.jl/actions/runs/29140401332/job/86512903689 (Issue 36 test in `test/Downstream/diffeq_tests.jl`).

## Root cause

LinearSolve >= v3.87 (and v5) types its `LUFactorization` cache slot from `ArrayInterface.lu_instance(A)` but stores `lu(A, check = false)` when not aliasing `A`. For a `ComponentMatrix`:

- `ArrayInterface.lu_instance(::ComponentMatrix)` (defined here) returns an `LU` wrapping a **ComponentMatrix**,
- `lu!(A)` also keeps the wrapper (ComponentMatrix is strided, so it hits LAPACK directly),
- but `lu(A)` copies through `similar(A, T, dims)`, which drops the axes and demotes to a plain **Matrix**.

Storing the `LU{..., Matrix, ...}` into the `LU{..., ComponentMatrix, ...}`-typed slot throws `TypeError: in setfield!`, which is exactly the downstream error:

```
TypeError: in setfield!, expected LinearAlgebra.LU{Float64, ComponentArrays.ComponentMatrix{...}, Vector{Int64}}, got a value of type LinearAlgebra.LU{Float64, Matrix{Float64}, Vector{Int64}}
```

This reproduces without OrdinaryDiffEq via a plain `solve(LinearProblem(A, b))` on a 2000x2000 `ComponentMatrix`.

## Fix

Make `lu(::ComponentMatrix)` factorize `getdata(A)` (keeping the LAPACK fast path) and rewrap the factors, so `lu`, `lu!`, and `lu_instance` all return the same type. The same treatment is applied to `qr`/`ArrayInterface.qr_instance`, because LinearSolve's default solver falls back to `QRFactorization` on singular matrices (`safetyfallback`) and `do_factorization` uses the in-place `qr!(A, pivot)` there, which hits the identical mismatch (slot typed `QRCompactWY{..., Matrix, ...}` from `qr_instance`, value `QRCompactWY{..., ComponentMatrix, ...}`) — i.e. any ODE solve whose W matrix goes singular would crash instead of falling back.

Note `GenericLUFactorization` (chosen by the default solver for sizes <= 10) stores `generic_lufact!(A)`, which wraps `A` itself, so its slot genuinely must be `LU{..., ComponentMatrix, ...}` — that is why the fix preserves the wrapper everywhere rather than demoting `lu_instance` to `Matrix` (which would just move the mismatch to the small-size path that currently passes).

## Verification (all run locally)

- MWE `solve(LinearProblem(A, b))` on a 2000x2000 ComponentMatrix: fails with the CI TypeError before, passes after (LinearSolve v5.0.0, Julia 1.12.6).
- Default solver sweep over sizes 4-2000 with `alias_A` in (false, true): all pass.
- Explicit `LUFactorization`, `GenericLUFactorization`, `QRFactorization`, `KrylovJL_GMRES`: all pass.
- Singular-matrix default solve (LU -> QR fallback): no longer throws, returns `Success` with the least-squares fallback.
- Type consistency `typeof(f(A)) === typeof(f!(copy(A))) === typeof(instance(A))` for lu and qr (NoPivot and ColumnNorm): verified on Julia 1.12.6 and 1.10.11.
- `GROUP=Core Pkg.test()` (Julia 1.12): pass, including new regression tests in `test/math_tests.jl`.
- `GROUP=Downstream Pkg.test()` (Julia 1.12): **6 passed, 1 broken** (the broken one is the pre-existing `@test_broken` Sundials Issue 53), versus `4 passed, 1 errored, 1 broken` on CI before this change.

Runic has been run on all changed files. Version bumped to 0.15.42.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PZG7J62sLGGMUmvNsKHVMA