### PR TITLE
Allow-list QRCompactWY instead of avoiding internal QR types

### DIFF
--- a/src/linear_algebra.jl
+++ b/src/linear_algebra.jl
@@ -27,13 +27,20 @@ function LinearAlgebra.qr(
         A::ComponentMatrix, pivot::Union{NoPivot, ColumnNorm} = NoPivot();
         kwargs...,
     )
-    return LinearAlgebra.qr!(copy(A), pivot; kwargs...)
+    F = LinearAlgebra.qr(getdata(A), pivot; kwargs...)
+    return _rewrap_qr(F, getaxes(A))
 end
 
 function ArrayInterface.qr_instance(A::ComponentMatrix, pivot = NoPivot())
-    instance = ComponentArray(zeros(eltype(A), 0, 0), getaxes(A)...)
-    return LinearAlgebra.qr!(instance, pivot)
+    F = ArrayInterface.qr_instance(getdata(A), pivot)
+    return _rewrap_qr(F, getaxes(A))
 end
+
+# QRCompactWY is not public LinearAlgebra API; allow-listed in test/qa/qa.jl.
+_rewrap_qr(F::LinearAlgebra.QRCompactWY, ax) = LinearAlgebra.QRCompactWY(ComponentArray(F.factors, ax), F.T)
+_rewrap_qr(F::LinearAlgebra.QRPivoted, ax) = LinearAlgebra.QRPivoted(ComponentArray(F.factors, ax), F.τ, F.jpvt)
+_rewrap_qr(F::LinearAlgebra.QR, ax) = LinearAlgebra.QR(ComponentArray(F.factors, ax), F.τ)
+_rewrap_qr(F, ax) = F
 
 # Helpers for dealing with adjoints and such
 _first_axis(x::AbstractComponentVecOrMat) = getaxes(x)[1]

--- a/test/math_tests.jl
+++ b/test/math_tests.jl
@@ -174,5 +174,13 @@ let A = cmat + I
     @test getaxes(Fqr_pivoted_instance.factors) == getaxes(A)
     @test typeof(Fqr_pivoted) === typeof(qr!(copy(A), ColumnNorm())) ===
         typeof(Fqr_pivoted_instance)
+
+    # Non-BLAS eltypes go through the generic `QR` factorization instead of `QRCompactWY`.
+    Abig = ComponentArray(big.(getdata(A)), getaxes(A))
+    Fqr_big = qr(Abig)
+    Fqr_big_instance = ComponentArrays.ArrayInterface.qr_instance(Abig, NoPivot())
+    @test Fqr_big.factors isa ComponentMatrix
+    @test Fqr_big_instance.factors isa ComponentMatrix
+    @test typeof(Fqr_big) === typeof(qr!(copy(Abig))) === typeof(Fqr_big_instance)
 end
 @test ComponentArrays.ArrayInterface.parent_type(cmat) === Matrix{Float64}

--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -16,7 +16,7 @@ run_qa(
                 :combine_axes, :dataids, :elsize, :maybeview, :print_array,
                 :print_matrix, :to_index, :unalias, :unsafe_convert,
                 # LinearAlgebra non-public (lu_instance/factorization internals):
-                :BlasInt, :lutype,
+                :BlasInt, :QRCompactWY, :lutype,
                 # Adapt non-public (adapt_storage/adapt_structure extension):
                 :adapt_storage, :adapt_structure,
                 # ChainRulesCore non-public:


### PR DESCRIPTION
Ignore this PR until it has been reviewed by @ChrisRackauckas.

## What changed

Rebased on `main` and inverted the approach: instead of routing around `LinearAlgebra.QRCompactWY`, use it directly and mark it as allowed in the QA config.

- restore concrete-type rewrapping in `LinearAlgebra.qr(::ComponentMatrix)` and `ArrayInterface.qr_instance(::ComponentMatrix)` (reverts the workaround merged in https://github.com/SciML/ComponentArrays.jl/pull/394)
- add `:QRCompactWY` to the `all_qualified_accesses_are_public` ignore list in `test/qa/qa.jl`
- add a `_rewrap_qr(::LinearAlgebra.QR, ax)` branch so non-BLAS eltypes (e.g. `BigFloat`) keep the `ComponentMatrix` wrapper too, with a regression test

## Why

`QRCompactWY` is genuinely not public LinearAlgebra API, but rewrapping by concrete factorization type is the direct way to keep the `ComponentMatrix` wrapper on the factors. Allow-listing the one non-public name is simpler than the `qr!`-on-a-0x0-instance indirection.

Verified locally that the allow-list entry is load-bearing: with it removed, QA errors with

```
`QRCompactWY` is not public in `LinearAlgebra` but it was imported from `LinearAlgebra` at src/linear_algebra.jl:41:29
```

## Local checks (Julia 1.12.4)

- `GROUP=QA`: 19 passed, 0 failed
- `GROUP=Core`: passed; `math_tests.jl` 102/102
- Runic v1.7.0 `--check`
- `GROUP=Downstream`: 23 passed, 1 broken (the pre-existing `@test_broken` at `test/Downstream/diffeq_tests.jl:31`)

Please ignore this draft until it has been reviewed by @ChrisRackauckas.
