### PR TITLE
Bump ComponentArrays to 0.15.44 for release

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ComponentArrays"
 uuid = "b0b7db55-cfe3-40fc-9ded-d10e2dbeff66"
 authors = ["Jonnie Diegelman <47193959+jonniedie@users.noreply.github.com>"]
-version = "0.15.43"
+version = "0.15.44"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"


### PR DESCRIPTION
These packages have unreleased changes to `src`, `ext`, or `Project.toml` relative to the
tree recorded in the General registry for their current version, but the version was never
bumped — so the changes cannot be released.

| package | from | to | kind | why |
|---|---|---|---|---|
| `ComponentArrays` | 0.15.43 | **0.15.44** | patch | unreleased changes to `src`/`ext`/`Project.toml` since the registered tree |

### How the versions were chosen

Patch by default. A package was promoted to a **minor** bump only where it gained public API
or a user-facing capability. For `0.y.z` packages the non-breaking slot is `z`, so those stay
in the patch position regardless of what they added.

No package in this PR needs a major bump: comparing the exported/`@public` name sets between
each package's released commit and master, **no name that the package itself defines was
removed**. The removals that do appear are blanket reexports of names owned by other packages
(e.g. `BVPJacobianAlgorithm` and `integral`, which belong to `BoundaryValueDiffEqCore`), which
SciML does not treat as documented public API.

Registration follows once this merges.

---

Found by a `/sciml-release-sweep` pass over the org. **Please ignore until reviewed by @ChrisRackauckas.**
