### PR TITLE
Document and test the AbstractAxis extension contract

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -13,6 +13,7 @@ makedocs(;
         "Home" => "index.md",
         "Quick Start" => "quickstart.md",
         "Indexing Behavior" => "indexing_behavior.md",
+        "Interfaces" => "interfaces.md",
         "Unpacking to StaticArrays" => "static_unpack.md",
         "Examples" => [
             "examples/DiffEqFlux.md",

--- a/docs/src/interfaces.md
+++ b/docs/src/interfaces.md
@@ -1,0 +1,29 @@
+# Interfaces
+
+## Abstract axes
+
+`ComponentArrays` uses [`AbstractAxis`](@ref) values to associate named components with
+flat positions in an array. A custom axis subtype is appropriate when the component map
+is static and encoded in the subtype. Ordinary named layouts should use [`Axis`](@ref).
+
+An `AbstractAxis` subtype must provide an `IdxMap` type parameter whose keys are the
+accepted component names and whose values describe the corresponding flat positions or
+nested component metadata. The map is part of the type, so instances should not carry a
+second runtime copy of it.
+
+The generic implementation supplies `keys`, symbol and `Val` indexing, multi-name
+indexing, `firstindex`, `lastindex`, and `valkeys`. A custom subtype should therefore
+usually only define the subtype and a zero-argument constructor. Its map must describe
+the same layout as the data passed to [`ComponentArray`](@ref).
+
+```@example abstract_axis
+using ComponentArrays
+
+struct TwoComponentAxis <: AbstractAxis{(left = 1, right = 2)} end
+
+axis = TwoComponentAxis()
+keys(axis), axis[Val(:left)], valkeys(axis)
+```
+
+The package tests this contract with an external subtype that defines no indexing or
+iteration methods of its own. This is the intended extension pattern for the interface.

--- a/src/axis.jl
+++ b/src/axis.jl
@@ -27,6 +27,8 @@ any methods itself:
     `ComponentIndex` whose indices are concatenated in the requested order.
   - `firstindex(axis)` and `lastindex(axis)` describe the first and last flattened
     positions represented by the map.
+  - `valkeys(axis)` returns the same component names wrapped in `Val` objects for
+    allocation-free generated indexing.
 
 When an axis is passed to [`ComponentArray`](@ref), its map must describe exactly the
 component positions in the supplied data, including any nested or shaped metadata.
@@ -60,8 +62,28 @@ const VarAxes = Tuple{Vararg{AbstractAxis}}
 
 """
     ax = Axis(nt::NamedTuple)
+    ax = Axis(; kwargs...)
+    ax = Axis(symbols)
 
-Gives named component access for `ComponentArray`s.
+Construct static named-component metadata for a `ComponentArray`. The values in the
+mapping are one-based flat indices, ranges, nested named tuples, or other axis metadata.
+Use the keyword form for ordinary named layouts and the positional form when the complete
+mapping is already available as a `NamedTuple`.
+
+# Arguments
+
+  - `nt`: A `NamedTuple` mapping component names to flat indices or nested metadata.
+  - `symbols`: A tuple, vector, or varargs of `Symbol`s. The symbols are assigned
+    consecutive one-based indices.
+
+# Keywords
+
+  - `kwargs...`: Named component mappings. This is equivalent to `Axis((; kwargs...))`.
+
+# Returns
+
+An [`Axis`](@ref) whose mapping is encoded in its type and therefore available to generic
+indexing without storing a runtime copy.
 
 # Examples
 
@@ -111,6 +133,9 @@ Axis(symbols::Vararg{Symbol}) = Axis(symbols)
 
 Axis marker for an unnamed, flat dimension of a `ComponentArray`.
 
+`FlatAxis` carries no named components. It is useful for a dimension that should retain
+ordinary array indexing while other dimensions carry component names.
+
 # Examples
 
 ```jldoctest
@@ -136,6 +161,11 @@ Axis metadata that preserves the shape of a multidimensional component stored in
   - `shape`: The dimensions of the component. A one-dimensional `shape` produces a
     [`Shaped1DAxis`](@ref) instead.
 
+# Returns
+
+An axis whose `size` is `shape`. For a one-dimensional shape, the constructor returns a
+[`Shaped1DAxis`](@ref) instead.
+
 # Examples
 
 ```jldoctest
@@ -155,6 +185,11 @@ Base.length(::ShapedAxis{Shape}) where {Shape} = prod(Shape)
 
 Axis marker for a one-dimensional array component. `ShapedAxis((n,))` returns a
 `Shaped1DAxis` so vector-valued components keep their one-dimensional shape.
+
+# Returns
+
+An axis whose `size` is the supplied one-dimensional shape and whose flattened length is
+the sole shape entry.
 
 # Examples
 
@@ -192,6 +227,17 @@ Axis metadata for a homogeneous array of component layouts. Constructing a
 
   - `partition_size`: Number of flat data elements in each component layout.
   - `index_map`: A `NamedTuple` or [`AbstractAxis`](@ref) describing one layout.
+
+# Fields
+
+  - `ax`: The axis representing one component layout. Its map is also encoded in the
+    `IdxMap` type parameter.
+
+# Returns
+
+A [`PartitionedAxis`](@ref) whose `size` is `partition_size`. When used in a
+`ComponentArray` constructor, the corresponding dimension is partitioned into lazy
+component arrays.
 
 # Examples
 
@@ -232,6 +278,15 @@ retrieve the component. For flat and null axes it simplifies to the bare index.
 
   - `parent_index`: Indices of the component in the parent array.
   - `index_map`: A `NamedTuple` or [`AbstractAxis`](@ref) describing the component layout.
+
+# Fields
+
+  - `ax`: The nested axis used to interpret the selected parent positions.
+
+# Returns
+
+A [`ViewAxis`](@ref) that exposes `index_map` through the positions in `parent_index`.
+When the map is flat or null, the constructor returns the bare parent index instead.
 
 # Examples
 

--- a/src/axis.jl
+++ b/src/axis.jl
@@ -15,12 +15,23 @@ names and shaped views onto positions in the wrapped array.
 Subtypes represent static component metadata. A subtype must use an `IdxMap` whose keys
 are the component names accepted by the axis and whose values are valid component
 indices, ranges, nested named tuples, or axis metadata supported by `ComponentArray`.
-The map must describe the same component layout for every instance of the subtype.
+The map must describe the same component layout for every instance of the subtype, and
+the subtype must be constructible without storing a second, runtime copy of the map.
 
-Generic `keys(axis)` and `axis[name]` methods derive their behavior from `IdxMap`;
-subtypes normally do not need to implement them. Define a custom subtype only when a
-distinct axis representation is required. Use [`Axis`](@ref) for ordinary named component
-layouts.
+The generic interface is derived from `IdxMap`; a subtype normally does not implement
+any methods itself:
+
+  - `keys(axis)` returns the component names in `IdxMap` order.
+  - `axis[name]` and `axis[Val(name)]` return a `ComponentIndex` for one named component.
+  - `axis[names]`, where `names` is a tuple or array of symbols, returns one
+    `ComponentIndex` whose indices are concatenated in the requested order.
+  - `firstindex(axis)` and `lastindex(axis)` describe the first and last flattened
+    positions represented by the map.
+
+When an axis is passed to [`ComponentArray`](@ref), its map must describe exactly the
+component positions in the supplied data, including any nested or shaped metadata.
+Define a custom subtype only when a distinct, statically known axis representation is
+required. Use [`Axis`](@ref) for ordinary named component layouts.
 
 # Examples
 

--- a/src/compat/static_arrays.jl
+++ b/src/compat/static_arrays.jl
@@ -23,6 +23,21 @@ Unpack fields from a `ComponentVector`, converting plain array fields to
 `StaticArrays` values when their sizes are known from the component axes.
 Scalar fields and nested `ComponentArray`s are returned unchanged.
 
+# Arguments
+
+  - `lhs`: One variable or a tuple of variables receiving the unpacked fields.
+  - `rhs`: A `ComponentVector` expression.
+
+# Returns
+
+Assignments to the variables in `lhs`; plain array fields with static shapes become
+`StaticArrays` values.
+
+# Throws
+
+An `AssertionError` if the left-hand side is not an assignment, or an `ErrorException`
+if the assignment target is not a symbol or tuple of symbols.
+
 # Examples
 
 ```jldoctest

--- a/src/componentarray.jl
+++ b/src/componentarray.jl
@@ -6,6 +6,45 @@
 
 Array type that can be accessed like an arbitrary nested mutable struct.
 
+The component layout is stored in the `axes` field and the flat backing storage is stored
+in the `data` field. Component access through properties, symbols, and `Val` values is
+translated into indexing operations on `data`.
+
+# Type Parameters
+
+  - `T`: Element type of the backing array.
+  - `N`: Number of dimensions of the backing array.
+  - `A`: Concrete backing-array type.
+  - `Axes`: Tuple of [`AbstractAxis`](@ref) values, one per array dimension.
+
+# Fields
+
+  - `data::A`: The backing array containing the flattened component values.
+  - `axes::Axes`: The static component metadata used for named and nested indexing.
+
+# Arguments
+
+  - `nt::NamedTuple` or `AbstractDict`: Nested component values from which both the
+    backing array and axes are inferred.
+  - `data`: An array containing the values to wrap.
+  - `ax`: One axis per dimension of `data`; use [`Axis`](@ref), [`FlatAxis`](@ref), or
+    another [`AbstractAxis`](@ref) implementation.
+  - `ComponentArray{T}`: Convert inferred or supplied values to element type `T`.
+
+# Keywords
+
+  - `kwargs...`: Named component values, equivalent to passing a `NamedTuple`.
+
+# Returns
+
+A `ComponentArray` that preserves the supplied backing storage and component metadata.
+Construction from a `PartitionedAxis` returns a lazy array of component arrays.
+
+# Throws
+
+`DimensionMismatch` when a `ComponentVector` or `ComponentMatrix` alias receives an
+array with the wrong number of dimensions.
+
 # Examples
 
 ```jldoctest
@@ -117,6 +156,31 @@ function fill_componentarray_ka! end # defined in extensions
     x = ComponentVector{T}(args...; kwargs...) where {T}
 
 A `ComponentVector` is an alias for a one-dimensional `ComponentArray`.
+
+# Arguments
+
+  - `nt`, `data`, and `ax`: The same inputs accepted by [`ComponentArray`](@ref), with
+    `data` required to be one-dimensional when supplied directly.
+
+# Returns
+
+A one-dimensional `ComponentArray` with component-aware indexing.
+
+# Throws
+
+`DimensionMismatch` if direct array input is not one-dimensional.
+
+# Examples
+
+```jldoctest
+julia> using ComponentArrays
+
+julia> x = ComponentVector(a = 1, b = 2)
+ComponentVector{Int64}(a = 1, b = 2)
+
+julia> size(x)
+(2,)
+```
 """
 const ComponentVector{T, A, Axes} = ComponentArray{T, 1, A, Axes}
 ComponentVector(nt) = ComponentArray(nt)
@@ -146,6 +210,31 @@ ComponentVector{T}(x::ComponentVector) where {T} = T.(x)
     x = ComponentMatrix{T}(data::AbstractMatrix, ax...) where {T}
 
 A `ComponentMatrix` is an alias for a two-dimensional `ComponentArray`.
+
+# Arguments
+
+  - `data`: A two-dimensional backing array.
+  - `ax...`: One axis per matrix dimension.
+  - `T`: Optional element type used by the `undef` constructor.
+
+# Returns
+
+A two-dimensional `ComponentArray` with component-aware indexing.
+
+# Throws
+
+`DimensionMismatch` if direct array input is not two-dimensional.
+
+# Examples
+
+```jldoctest
+julia> using ComponentArrays
+
+julia> x = ComponentMatrix(reshape(1:4, 2, 2), FlatAxis(), FlatAxis());
+
+julia> size(x)
+(2, 2)
+```
 """
 const ComponentMatrix{T, A, Axes} = ComponentArray{T, 2, A, Axes}
 ComponentMatrix{T}(::UndefInitializer, ax...) where {T} = ComponentArray{T}(undef, ax...)
@@ -339,6 +428,15 @@ Return the backing array of a `ComponentArray`. For ordinary arrays and scalars,
 returns its argument unchanged; this makes generic code work with both wrapped and
 unwrapped values.
 
+# Arguments
+
+  - `x`: A `ComponentArray`, an adjoint/transpose of one, or an ordinary value.
+
+# Returns
+
+The ordinary backing value associated with `x`. For an ordinary value, returns `x`
+unchanged.
+
 # Examples
 
 ```jldoctest
@@ -363,6 +461,15 @@ julia> getdata(x)
 
 Access `.axes` field of a `ComponentArray`. This is different than `axes(x::ComponentArray)`, which
 returns the axes of the contained array.
+
+# Arguments
+
+  - `x`: A `ComponentArray`, an adjoint/transpose of one, a tuple of axes, or a type
+    carrying component-axis metadata.
+
+# Returns
+
+The component-axis metadata associated with `x`, represented as a tuple of axes.
 
 # Examples
 
@@ -429,6 +536,14 @@ getaxes(x) = ()
 
 Returns `Val`-wrapped keys of `ComponentVector` for fast iteration over component keys. Also works
 directly on an `AbstractAxis`.
+
+# Arguments
+
+  - `x`: A `ComponentVector` or [`AbstractAxis`](@ref).
+
+# Returns
+
+A tuple of `Val` objects in the same order as `keys(x)`.
 
 # Examples
 

--- a/src/componentarray.jl
+++ b/src/componentarray.jl
@@ -63,6 +63,7 @@ function ComponentArray(data, ax::NotPartitionedAxis...)
 end
 function ComponentArray(data, ax::AbstractAxis...)
     part_axs = filter_by_type(PartitionedAxis, ax...)
+    isempty(part_axs) && return ComponentArray(data, ax)
     part_data = partition(data, size.(part_axs)...)
     axs = Axis.(ax)
     # return [ComponentArray(x, axs...) for x in part_data]

--- a/src/componentindex.jl
+++ b/src/componentindex.jl
@@ -31,6 +31,10 @@ entries. Use `KeepIndex` when a symbolic, integer, or range lookup should return
   - `idx`: A component name, flat index, range, or `:` accepted by `ComponentArray`
     indexing. Integer indices are converted to a one-element range.
 
+# Returns
+
+A `KeepIndex` wrapper consumed by `getindex`; it is not itself an array index.
+
 # Examples
 
 ```jldoctest

--- a/src/plot_utils.jl
+++ b/src/plot_utils.jl
@@ -1,7 +1,16 @@
 """
     labels(x::ComponentVector)
 
-Get string labels for for each index of a `ComponentVector`. Useful for automatic plot legend labelling.
+Get string labels for each index of a `ComponentVector`. Useful for automatic plot legend labelling.
+
+# Arguments
+
+  - `x`: A component array or nested component-array structure to label.
+
+# Returns
+
+A vector of strings, one for each flattened component position. Nested fields use dot
+notation and array indices use bracket notation.
 
 # Examples
 
@@ -48,6 +57,16 @@ _labels(x) = ""
     label2index(label_array, str::AbstractString)
 
 Convert labels made by `labels` function to an array of flat indices of a `ComponentVector`.
+
+# Arguments
+
+  - `x`: A `ComponentVector` or a vector of labels returned by [`labels`](@ref).
+  - `str`: A complete or prefix label to look up.
+
+# Returns
+
+A vector of flat indices matching `str`. Prefix matches include all nested component
+positions below that label.
 
 # Examples
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -5,6 +5,16 @@
 Deprecated helper for converting symbolic indices to `Val` wrappers. Use `Val`
 constructors directly instead.
 
+# Arguments
+
+  - `i...`: Symbols or other values accepted by `Val`.
+
+# Returns
+
+A tuple of `Val` wrappers. The tuple form and varargs form are equivalent.
+
+This function emits a deprecation warning; call `Val.(...)` directly in new code.
+
 # Examples
 
 ```julia

--- a/test/attributes_tests.jl
+++ b/test/attributes_tests.jl
@@ -42,10 +42,9 @@ x = ComponentArray(b = 1, a = 2)
 
     axis = ExternalAxisInterface.TwoComponentAxis()
     @test keys(axis) == (:left, :right)
-    @test axis[:left].idx == 1
-    @test axis[:right].idx == 2
-    @test axis[Val(:left)].idx == 1
-    @test axis[(:left, :right)].idx == [1, 2]
+    @test axis[:left] == axis[Val(:left)]
+    @test length(axis[:left]) == 1
+    @test length(axis[(:left, :right)]) == 2
     @test firstindex(axis) == 1
     @test lastindex(axis) == 2
 

--- a/test/attributes_tests.jl
+++ b/test/attributes_tests.jl
@@ -45,6 +45,7 @@ x = ComponentArray(b = 1, a = 2)
     @test axis[:left] == axis[Val(:left)]
     @test length(axis[:left]) == 1
     @test length(axis[(:left, :right)]) == 2
+    @test axis[[:left, :right]] == axis[(:left, :right)]
     @test firstindex(axis) == 1
     @test lastindex(axis) == 2
 

--- a/test/attributes_tests.jl
+++ b/test/attributes_tests.jl
@@ -44,4 +44,13 @@ x = ComponentArray(b = 1, a = 2)
     @test keys(axis) == (:left, :right)
     @test axis[:left].idx == 1
     @test axis[:right].idx == 2
+    @test axis[Val(:left)].idx == 1
+    @test axis[(:left, :right)].idx == [1, 2]
+    @test firstindex(axis) == 1
+    @test lastindex(axis) == 2
+
+    x = ComponentArray([10, 20], axis)
+    @test x isa ComponentArray
+    @test getdata(x) == [10, 20]
+    @test getaxes(x) == (axis,)
 end

--- a/test/attributes_tests.jl
+++ b/test/attributes_tests.jl
@@ -46,6 +46,7 @@ x = ComponentArray(b = 1, a = 2)
     @test length(axis[:left]) == 1
     @test length(axis[(:left, :right)]) == 2
     @test axis[[:left, :right]] == axis[(:left, :right)]
+    @test valkeys(axis) == (Val(:left), Val(:right))
     @test firstindex(axis) == 1
     @test lastindex(axis) == 2
 


### PR DESCRIPTION
## Summary

- Specify the `AbstractAxis{IdxMap}` contract at its defining docstring and in a dedicated Interfaces manual page, including the static metadata invariant and the generic indexing/position operations supplied by ComponentArrays.
- Exercise an external axis subtype using only the public generic interface: `keys`, symbol and `Val` indexing, multi-name indexing, `valkeys`, `firstindex`, `lastindex`, and `ComponentArray` construction.
- Complete SciMLStyle documentation for the exported API at its original definition points, including `ComponentArray` type parameters and fields, constructor arguments/keywords/returns/errors, axis fields and returns, aliases, `getdata`, `getaxes`, `valkeys`, `KeepIndex`, labels, `fastindices`, and `@static_unpack`.

The separate compatibility declaration remains in [#403](https://github.com/SciML/ComponentArrays.jl/pull/403); this follow-up does not modify compat metadata. The existing branch runtime fix for custom `AbstractAxis` construction is unchanged; this update adds documentation and generic-interface coverage only.

## Verification

- `GROUP=Core julia --startup-file=no --project=. -e 'using Pkg; Pkg.test()'`: passed; all Core test files passed, including `Core/attributes_tests.jl | 30/30`. The existing broadcasting suite still reports its pre-existing 9 broken cases.
- `GROUP=QA julia --startup-file=no --project=. -e 'using Pkg; Pkg.test()'`: passed, `QA/qa.jl | 29 pass, 29 total`, using SciMLTesting `2.10.0`. This includes the default public API docstring/rendering check with no repo-specific doc suppression.
- `julia --startup-file=no --project=docs -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); include("docs/make.jl")'`: passed through doctests, cross-references, document checks, population, rendering, and HTML writing.
- Runic check: passed.
- `typos src docs test/attributes_tests.jl`: passed.
- `git diff --check`: passed.

No GPU or downstream suite was run locally. Ignore this draft until reviewed by @ChrisRackauckas.