### PR TITLE
compat: raise SciMLTesting floor to 2.10

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -58,4 +58,8 @@ StaticArraysCore = "1.4.2"
 SymbolicIndexingInterface = "0.3.40, 1"
 Tracker = "0.2.37"
 Zygote = "0.6.70, 0.7"
+SciMLTesting = "2.4"
 julia = "1.10"
+
+[extras]
+SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"

--- a/Project.toml
+++ b/Project.toml
@@ -58,7 +58,7 @@ StaticArraysCore = "1.4.2"
 SymbolicIndexingInterface = "0.3.40, 1"
 Tracker = "0.2.37"
 Zygote = "0.6.70, 0.7"
-SciMLTesting = "2.4"
+SciMLTesting = "2.10"
 julia = "1.10"
 
 [extras]


### PR DESCRIPTION
This is a mechanical compat-only PR. Raise every affected root/sublibrary SciMLTesting compat entry from 2.1 to 2.10 so the repository uses the strict SciMLTesting QA defaults. No source, test behavior, or documentation changes are included. Please ignore this draft until reviewed by @ChrisRackauckas. Local git diff --check and typos checks pass.