### PR TITLE
Fix nested return from axpy! and axpby!

### DIFF
--- a/src/linear_algebra.jl
+++ b/src/linear_algebra.jl
@@ -85,13 +85,13 @@ end
 function LinearAlgebra.axpy!(α::Number, x::ComponentArray, y::ComponentArray)
     getaxes(x) != getaxes(y) && throw(ArgumentError("Axes of `x` and `y` must match"))
     axpy!(α, getdata(x), getdata(y))
-    return ComponentArray(y, getaxes(y))
+    return y
 end
 
 function LinearAlgebra.axpby!(α::Number, x::ComponentArray, β::Number, y::ComponentArray)
     getaxes(x) != getaxes(y) && throw(ArgumentError("Axes of `x` and `y` must match"))
     axpby!(α, getdata(x), β, getdata(y))
-    return ComponentArray(y, getaxes(y))
+    return y
 end
 
 function LinearAlgebra.ldiv!(B::AbstractVecOrMat, D::Diagonal{Float64, <:ComponentArray}, A::AbstractVecOrMat)

--- a/test/axpy_axpby_tests.jl
+++ b/test/axpy_axpby_tests.jl
@@ -3,9 +3,18 @@ include("shared/test_setup.jl")
 y = ComponentArray(a = rand(4), b = rand(4))
 x = ComponentArray(a = rand(4), b = rand(4))
 ydata = copy(getdata(y))
+ystorage = getdata(y)
 
-axpy!(2, x, y)
+result = axpy!(2, x, y)
+@test result === y
+@test getdata(result) === ystorage
 @test getdata(y) == 2 .* getdata(x) .+ ydata
+
+previous = copy(getdata(y))
+result = axpy!(2, x, result)
+@test result === y
+@test getdata(result) === ystorage
+@test getdata(y) == 2 .* getdata(x) .+ previous
 
 x = ComponentArray(a = rand(4), c = rand(4))
 @test_throws ArgumentError axpy!(2, x, y)
@@ -13,9 +22,18 @@ x = ComponentArray(a = rand(4), c = rand(4))
 y = ComponentArray(a = rand(4), b = rand(4))
 x = ComponentArray(a = rand(4), b = rand(4))
 ydata = copy(getdata(y))
+ystorage = getdata(y)
 
-axpby!(2, x, 3, y)
+result = axpby!(2, x, 3, y)
+@test result === y
+@test getdata(result) === ystorage
 @test getdata(y) == 2 .* getdata(x) .+ 3 .* ydata
+
+previous = copy(getdata(y))
+result = axpby!(1, x, 1, result)
+@test result === y
+@test getdata(result) === ystorage
+@test getdata(y) == getdata(x) .+ previous
 
 x = ComponentArray(a = rand(4), c = rand(4))
 @test_throws ArgumentError axpby!(2, x, 3, y)


### PR DESCRIPTION
## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API
  
## Additional context

- Fixes #406.
- Returns the mutated destination directly from `axpy!` and `axpby!`.
- Adds regression tests for repeated accumulation.