### PR TITLE
QA: remove broad Aqua suppressions

### DIFF
--- a/src/array_interface.jl
+++ b/src/array_interface.jl
@@ -85,24 +85,25 @@ function Base.vcat(x::AbstractComponentVecOrMat{<:Number}, y::AbstractComponentV
         return ComponentArray(vcat(data_x, data_y), Axis((; idxmap_x..., idxmap_y...)), getaxes(x)[2:end]...)
     end
 end
-function Base.vcat(x::CV...) where {CV <: AdjOrTransComponentArray{<:Number}}
-    return ComponentArray(reduce(vcat, map(y -> getdata(y.parent)', x)), getaxes(x[1]))
+function Base.vcat(
+        x::ComponentVector{<:Number}, y::AbstractComponentArray,
+        z::AbstractComponentArray, args::Vararg{AbstractComponentArray}
+    )
+    return vcat(getdata(x), getdata(y), getdata(z), getdata.(args)...)
 end
-Base.vcat(x::ComponentVector{<:Number}, args...) = vcat(getdata(x), getdata.(args)...)
+function Base.vcat(
+        x::AdjOrTransComponentArray{<:Number},
+        ys::Vararg{AdjOrTransComponentArray{<:Number}}
+    )
+    arrays = (x, ys...)
+    return ComponentArray(reduce(vcat, map(y -> getdata(parent(y))', arrays)), getaxes(x))
+end
 function Base.vcat(
         x::ComponentVector{<:Number},
         args::Vararg{Union{Number, UniformScaling, AbstractVecOrMat{<:Number}}}
     )
     return vcat(getdata(x), getdata.(args)...)
 end
-function Base.vcat(
-        x::ComponentVector{<:Number}, args::Vararg{
-            AbstractVector{T}, N,
-        }
-    ) where {T <: Number, N}
-    return vcat(getdata(x), getdata.(args)...)
-end
-
 function Base.hvcat(row_lengths::NTuple{N, Int}, xs::Vararg{AbstractComponentVecOrMat}) where {N}
     i = 1
     idxs = UnitRange{Int}[]
@@ -125,17 +126,6 @@ function Base.IndexStyle(::Type{<:ComponentArray{T, N, <:A, <:Axes}}) where {T, 
     return IndexStyle(A)
 end
 
-# Since we aren't really using the standard approach to indexing, this will forward things to
-# the correct methods
-Base.to_indices(x::ComponentArray, i::Tuple{Any}) = i
-function Base.to_indices(
-        x::ComponentArray, i::NTuple{
-            N, Union{Integer, CartesianIndex},
-        }
-    ) where {N}
-    return i
-end
-Base.to_indices(x::ComponentArray, i::NTuple{N, Int64}) where {N} = i
 Base.to_index(x::ComponentArray, i) = i
 
 # Get ComponentArray index
@@ -149,7 +139,8 @@ end
 Base.@propagate_inbounds Base.getindex(x::ComponentArray, ::Colon) = getdata(x)[:]
 Base.@propagate_inbounds Base.getindex(x::ComponentArray, ::Colon, ::Vararg{Colon}) = x
 @inline Base.getindex(x::ComponentArray, idx...) = getindex(x, toval.(idx)...)
-@inline Base.getindex(x::ComponentArray, idx::Vararg{Val}) = _getindex(getindex, x, idx...)
+@inline Base.getindex(x::ComponentArray, idx::Val, idxs::Vararg{Val}) =
+    _getindex(getindex, x, idx, idxs...)
 
 # Set ComponentArray index
 Base.@propagate_inbounds Base.setindex!(
@@ -157,7 +148,8 @@ Base.@propagate_inbounds Base.setindex!(
 ) = setindex!(getdata(x), v, idx...)
 Base.@propagate_inbounds Base.setindex!(x::ComponentArray, v, ::Colon) = setindex!(getdata(x), v, :)
 @inline Base.setindex!(x::ComponentArray, v, idx...) = setindex!(x, v, toval.(idx)...)
-@inline Base.setindex!(x::ComponentArray, v, idx::Vararg{Val}) = _setindex!(x, v, idx...)
+@inline Base.setindex!(x::ComponentArray, v, idx::Val, idxs::Vararg{Val}) =
+    _setindex!(x, v, idx, idxs...)
 
 # Explicitly view
 Base.@propagate_inbounds Base.view(
@@ -166,11 +158,13 @@ Base.@propagate_inbounds Base.view(
 Base.@propagate_inbounds Base.view(x::ComponentArray, idx...) = _getindex(view, x, toval.(idx)...)
 
 Base.@propagate_inbounds Base.maybeview(
-    x::ComponentArray, idx::Vararg{ComponentArrays.FlatIdx}
-) = Base.maybeview(getdata(x), idx...)
+    x::ComponentArray, idx::ComponentArrays.FlatIdx,
+    idxs::Vararg{ComponentArrays.FlatIdx}
+) = Base.maybeview(getdata(x), idx, idxs...)
 Base.@propagate_inbounds Base.maybeview(
-    x::ComponentArray, idx...
-) = _getindex(Base.maybeview, x, toval.(idx)...)
+    x::ComponentArray, idx::Union{Symbol, Val, KeepIndex},
+    idxs::Vararg{Union{Symbol, Val, KeepIndex}}
+) = _getindex(Base.maybeview, x, toval(idx), toval.(idxs)...)
 
 # Generated get and set index methods to do all of the heavy lifting in the type domain
 @generated function _getindex(index_fun, x::ComponentArray, idx...)
@@ -215,7 +209,6 @@ for f in [:device, :stride_rank, :contiguous_axis, :contiguous_batch_size, :dens
     ) where {T, N, A, Axes} = StaticArrayInterface.$f(A)
 end
 
-Base.stride(x::ComponentArray, k) = stride(getdata(x), k)
-Base.stride(x::ComponentArray, k::Int64) = stride(getdata(x), k)
+Base.stride(x::ComponentArray, k::Integer) = stride(getdata(x), k)
 
 ArrayInterface.parent_type(::Type{ComponentArray{T, N, A, Axes}}) where {T, N, A, Axes} = A

--- a/src/axis.jl
+++ b/src/axis.jl
@@ -123,7 +123,7 @@ julia> ca.c.b
 struct Axis{IdxMap} <: AbstractAxis{IdxMap} end
 @inline Axis(IdxMap::NamedTuple) = Axis{IdxMap}()
 Axis(; kwargs...) = Axis((; kwargs...))
-function Axis(symbols::Union{AbstractVector{Symbol}, NTuple{N, Symbol}}) where {N}
+function Axis(symbols::Union{AbstractVector{Symbol}, Tuple{Vararg{Symbol}}})
     return Axis(NamedTuple{(symbols...,)}((eachindex(symbols)...,)))
 end
 Axis(symbols::Vararg{Symbol}) = Axis(symbols)
@@ -389,9 +389,9 @@ end
 } = ComponentIndex(getproperty(IdxMap, s))
 function Base.getindex(
         ax::AbstractAxis, syms::Union{
-            NTuple{N, Symbol}, <:AbstractArray{Symbol},
+            Tuple{Vararg{Symbol}}, <:AbstractArray{Symbol},
         }
-    ) where {N}
+    )
     @assert allunique(syms) "Indexing symbols must all be unique. Got $syms"
     c_inds = getindex.((ax,), syms)
     inds = map(x -> x.idx, c_inds)

--- a/src/componentarray.jl
+++ b/src/componentarray.jl
@@ -288,7 +288,6 @@ allocate_numeric_container(::Type) = []
 
 # For making ComponentArrays from named tuples
 make_carray_args(::NamedTuple{(), Tuple{}}) = (Any[], FlatAxis())
-make_carray_args(::Type{T}, ::NamedTuple{(), Tuple{}}) where {T} = (T[], FlatAxis())
 function make_carray_args(nt)
     data, ax = make_carray_args(Vector, nt)
     data = length(data) == 1 ? [data[1]] : map(identity, data)

--- a/test/math_tests.jl
+++ b/test/math_tests.jl
@@ -58,6 +58,8 @@ x = ComponentArray(;
 
 vca2 = vcat(ca2', ca2')
 hca2 = hcat(ca2, ca2)
+@test vca2 isa ComponentArray
+@test getaxes(vca2) == getaxes(ca2')
 temp = ComponentVector(q = 100, r = rand(3, 3, 3))
 vtempca = [temp; ca]
 @test all(vca2[1, :] .== ca2)

--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -1,4 +1,4 @@
-using SciMLTesting, ComponentArrays, Test
+using SciMLTesting, ComponentArrays, LinearAlgebra, Test
 using JET
 
 # ExplicitImports only walks an extension that is actually loaded (it resolves each
@@ -24,10 +24,18 @@ end
 
 run_qa(
     ComponentArrays;
-    # ComponentArrays has real method ambiguities and unbound type parameters in its
-    # vcat/hcat/getindex/Axis overloads; these are long-standing design realities, not
-    # tracked-broken placeholders, so disable the sub-checks rather than fail.
-    aqua_kwargs = (; ambiguities = false, unbound_args = false),
+    # These generic operations are required to interoperate with Base, stdlib, and
+    # foreign array/AD types. Aqua reports their intersections with Base, LinearAlgebra,
+    # Static, StructArrays, SparseArrays, Tracker, ReverseDiff, and Reactant methods;
+    # its function-level allowlist is the narrowest way to exclude those external pairs.
+    aqua_kwargs = (;
+        ambiguities = (;
+            exclude = [
+                Base.vcat, Base.copyto!, Base.:(==), LinearAlgebra.ldiv!,
+                Base.:(*), Base.getindex, Base.Broadcast.axistype, Base.similar,
+            ],
+        ),
+    ),
     ei_kwargs = (;
         all_qualified_accesses_are_public = (;
             ignore = (


### PR DESCRIPTION
## Summary

Remove the broad `ambiguities=false` and `unbound_args=false` Aqua suppressions.

- Narrow the affected Base array method signatures and retain transpose concatenation metadata.
- Add a regression assertion for transpose concatenation.
- Use a function-level Aqua ambiguity allowlist only for the remaining generic Base/stdlib/foreign-array method intersections.

## Verification

- `GROUP=QA ... julia +1.10 ... Pkg.test()` passed: `QA/qa.jl | 29 | 29`; SciMLTesting was `2.12.0`.
- `GROUP=Core ... julia +1.10 ... Pkg.test()` passed; `Core/math_tests.jl | 104 | 104` and the full Core group passed.
- Runic formatting passed.
- `typos` passed.
- `git diff --check` passed.

A Julia 1.12 QA attempt was blocked before assertions by a RuntimeGeneratedFunctions world-age precompile failure while loading RecursiveArrayTools; this is not the verified package result.

Please ignore this draft until reviewed by @ChrisRackauckas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://chatgpt.com/codex/tasks/019f4028-d2ae-7a12-aff0-7d996bd9c791